### PR TITLE
Halt client threads on database errors

### DIFF
--- a/src/main/java/io/github/utplsql/cli/RunCommand.java
+++ b/src/main/java/io/github/utplsql/cli/RunCommand.java
@@ -135,6 +135,7 @@ public class RunCommand {
             } catch (SQLException e) {
                 System.out.println(e.getMessage());
                 returnCode[0] = Cli.DEFAULT_ERROR_CODE;
+                executorService.shutdownNow();
             }
         });
 
@@ -158,6 +159,7 @@ public class RunCommand {
                 } catch (SQLException | FileNotFoundException e) {
                     System.out.println(e.getMessage());
                     returnCode[0] = Cli.DEFAULT_ERROR_CODE;
+                    executorService.shutdownNow();
                 } finally {
                     if (fileOutStream != null)
                         fileOutStream.close();


### PR DESCRIPTION
Fix #28 
If any unexpected database errors occur on the client, it will force the threads to shut down.