### PR TITLE
Adjust the fetchSize of reporters to 1 if writing to screen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
-      <version>1.69</version>
+      <version>1.72</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/utplsql/cli/ReporterManager.java
+++ b/src/main/java/org/utplsql/cli/ReporterManager.java
@@ -92,6 +92,7 @@ class ReporterManager {
                 try (Connection conn = ci.getConnection()) {
                     if (ro.outputToScreen()) {
                         printStreams.add(System.out);
+                        ro.getReporterObj().getOutputBuffer().setFetchSize(1);
                     }
 
                     if (ro.outputToFile()) {

--- a/src/test/java/org/utplsql/cli/RunCommandIT.java
+++ b/src/test/java/org/utplsql/cli/RunCommandIT.java
@@ -14,6 +14,7 @@ public class RunCommandIT {
     public void run_Default() throws Exception {
         RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(),
                 "-f=ut_documentation_reporter",
+                "-s",
                 "-c",
                 "--failure-exit-code=2");
 


### PR DESCRIPTION
Reporters which print to screen have their fetchSize set to 1. All others use a fetchSize of 100, which should improve performance.