### PR TITLE
Version info and info command in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,28 @@ export LC_ALL=en_US.utf-8
 The charset-part of LC_ALL is ignored.
 
 ## Usage
-Currently, utPLSQL-cli knows the following commands:
+Currently, utPLSQL-cli supports the following commands:
 - run
 - info
 - reporters
 
+#### \<ConnectionURL>
+
+This is used in all commands as first parameter (though it's optional for `info`).
+
+Accepted formats:
+
+- `<user>/<password>@//<host>[:<port>]/<service>`
+- `<user>/<password>@<host>:<port>:<SID>` 
+- `<user>/<password>@<TNSName>`
+                         
+To connect using TNS, you need to have the ORACLE_HOME environment variable set.
+The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
+The file tnsnames.ora must contain valid TNS entries. 
+
 ### run
 `utplsql run <ConnectionURL> [<options>]`
                                                                  
-```
-<ConnectionURL>     - accepted formats:
-                        <user>/<password>@//<host>[:<port>]/<service>
-                        <user>/<password>@<host>:<port>:<SID> 
-                        <user>/<password>@<TNSName> 
-                      To connect using TNS, you need to have the ORACLE_HOME environment variable set.
-                      The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
-                      The file tnsnames.ora must contain valid TNS entries. 
-```
 
 #### Options
 ```                       
@@ -133,15 +138,6 @@ Invokes all unit test suites from schema "hr". Results are displayed to screen u
 ### info
 `utplsql info [<ConnectionURL>]`
 
-```
-<ConnectionURL>     - accepted formats:
-                        <user>/<password>@//<host>[:<port>]/<service>
-                        <user>/<password>@<host>:<port>:<SID> 
-                        <user>/<password>@<TNSName> 
-                      To connect using TNS, you need to have the ORACLE_HOME environment variable set.
-                      The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
-                      The file tnsnames.ora must contain valid TNS entries. 
-```
 
 #### Examples
 
@@ -160,17 +156,7 @@ utPLSQL 3.1.2.1913
 ```
 
 ### reporters
-`utplsql info <ConnectionURL>`
-
-```
-<ConnectionURL>     - accepted formats:
-                        <user>/<password>@//<host>[:<port>]/<service>
-                        <user>/<password>@<host>:<port>:<SID> 
-                        <user>/<password>@<TNSName> 
-                      To connect using TNS, you need to have the ORACLE_HOME environment variable set.
-                      The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
-                      The file tnsnames.ora must contain valid TNS entries. 
-```
+`utplsql reporters <ConnectionURL>`
 
 #### Examples
 ```

--- a/README.md
+++ b/README.md
@@ -162,42 +162,42 @@ utPLSQL 3.1.2.1913
 ```
 > utplsql reporters app/app@localhost:1521/ORCLPDB1
 
-UT_COVERAGE_COBERTURA_REPORTER (SQL): Generates a Cobertura coverage report providing information on code coverage with line numbers.
-Designed for Jenkins and TFS to report coverage. 
-Cobertura Document Type Definition can be found: http://cobertura.sourceforge.net/xml/coverage-04.dtd.
-Sample file: https://github.com/leobalter/testing-examples/blob/master/solutions/3/report/cobertura-coverage.xml.
+UT_COVERAGE_COBERTURA_REPORTER Generates a Cobertura coverage report providing information on code coverage with line numbers.
+                               Designed for Jenkins and TFS to report coverage.
+                               Cobertura Document Type Definition can be found: http://cobertura.sourceforge.net/xml/coverage-04.dtd.
+                               Sample file: https://github.com/leobalter/testing-examples/blob/master/solutions/3/report/cobertura-coverage.xml.
 
-UT_COVERAGE_HTML_REPORTER (SQL_WITH_JAVA): Generates a HTML coverage report with summary and line by line information on code coverage.
-Based on open-source simplecov-html coverage reporter for Ruby.
-Includes source code in the report.
-Will copy all necessary assets to a folder named after the Output-File
+UT_COVERAGE_HTML_REPORTER      Generates a HTML coverage report with summary and line by line information on code coverage.
+                               Based on open-source simplecov-html coverage reporter for Ruby.
+                               Includes source code in the report.
+                               Will copy all necessary assets to a folder named after the Output-File
 
-UT_COVERAGE_SONAR_REPORTER (SQL): Generates a JSON coverage report providing information on code coverage with line numbers.
-Designed for [SonarQube](https://about.sonarqube.com/) to report coverage.
-JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
+UT_COVERAGE_SONAR_REPORTER     Generates a JSON coverage report providing information on code coverage with line numbers.
+                               Designed for [SonarQube](https://about.sonarqube.com/) to report coverage.
+                               JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
 
-UT_COVERALLS_REPORTER (SQL): Generates a JSON coverage report providing information on code coverage with line numbers.
-Designed for [Coveralls](https://coveralls.io/).
-JSON format conforms with specification: https://docs.coveralls.io/api-introduction
+UT_COVERALLS_REPORTER          Generates a JSON coverage report providing information on code coverage with line numbers.
+                               Designed for [Coveralls](https://coveralls.io/).
+                               JSON format conforms with specification: https://docs.coveralls.io/api-introduction
 
-UT_DOCUMENTATION_REPORTER (SQL_WITH_JAVA): A textual pretty-print of unit test results (usually use for console output)
-Provides additional properties lvl and failed
+UT_DOCUMENTATION_REPORTER      A textual pretty-print of unit test results (usually use for console output)
+                               Provides additional properties lvl and failed
 
-UT_JUNIT_REPORTER (SQL): Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
+UT_JUNIT_REPORTER              Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
 
-UT_SONAR_TEST_REPORTER (SQL): Generates a JSON report providing detailed information on test execution.
-Designed for [SonarQube](https://about.sonarqube.com/) to report test execution.
-JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
+UT_SONAR_TEST_REPORTER         Generates a JSON report providing detailed information on test execution.
+                               Designed for [SonarQube](https://about.sonarqube.com/) to report test execution.
+                               JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
 
-UT_TEAMCITY_REPORTER (SQL): Provides the TeamCity (a CI server by jetbrains) reporting-format that allows tracking of progress of a CI step/task as it executes.
-https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
+UT_TEAMCITY_REPORTER           Provides the TeamCity (a CI server by jetbrains) reporting-format that allows tracking of progress of a CI step/task as it executes.
+                               https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
 
-UT_TFS_JUNIT_REPORTER (SQL): Provides outcomes in a format conforming with JUnit version for TFS / VSTS.
-    As defined by specs :https://docs.microsoft.com/en-us/vsts/build-release/tasks/test/publish-test-results?view=vsts
-    Version is based on windy road junit https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd.
+UT_TFS_JUNIT_REPORTER          Provides outcomes in a format conforming with JUnit version for TFS / VSTS.
+                               As defined by specs :https://docs.microsoft.com/en-us/vsts/build-release/tasks/test/publish-test-results?view=vsts
+                               Version is based on windy road junit https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd.
 
-UT_XUNIT_REPORTER (SQL): Depracated reporter. Please use Junit.
-    Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
+UT_XUNIT_REPORTER              Depracated reporter. Please use Junit.
+                               Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
 ```
 
 ## Enabling Color Outputs on Windows

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The charset-part of LC_ALL is ignored.
 Currently, utPLSQL-cli knows the following commands:
 - run
 - info
+- reporters
 
 ### run
 `utplsql run <ConnectionURL> [<options>]`
@@ -68,7 +69,7 @@ Currently, utPLSQL-cli knows the following commands:
                       
 -f=format           - A reporter to be used for reporting.
                       If no -f option is provided, the default ut_documentation_reporter is used.
-                      See reporters list for possible values
+                      See reporters command for possible values
   -o=output         - Defines file name to save the output from the specified reporter.
                       If defined, the output is not displayed on screen by default. This can be changed with the -s parameter.
                       If not defined, then output will be displayed on screen, even if the parameter -s is not specified.
@@ -115,7 +116,7 @@ Sonar and Coveralls reporter will only provide valid reports, when source_path a
 #### Examples
 
 ```
-utplsql run hr/hr@xe -p=hr_test -f=ut_documentation_reporter -o=run.log -s -f=ut_coverage_html_reporter -o=coverage.html -source_path=source
+> utplsql run hr/hr@xe -p=hr_test -f=ut_documentation_reporter -o=run.log -s -f=ut_coverage_html_reporter -o=coverage.html -source_path=source
 ```
 
 Invokes all Unit tests from schema/package "hr_test" with two reporters:
@@ -124,7 +125,7 @@ Invokes all Unit tests from schema/package "hr_test" with two reporters:
 * ut_coverage_html_reporter - will report only on database objects that are mapping to file structure from "source" folder and save output to file "coverage.html"
 
 ```
-utplsql run hr/hr@xe
+> utplsql run hr/hr@xe
 ```
 
 Invokes all unit test suites from schema "hr". Results are displayed to screen using default ut_documentation_reporter.
@@ -145,19 +146,73 @@ Invokes all unit test suites from schema "hr". Results are displayed to screen u
 #### Examples
 
 ```
-utplsql info
+> utplsql info
 
-> cli 3.1.1-SNAPSHOT.local
-> utPLSQL-java-api 3.1.1-SNAPSHOT.123
+cli 3.1.1-SNAPSHOT.local
+utPLSQL-java-api 3.1.1-SNAPSHOT.123
 ```
 ```
-utplsql info app/app@localhost:1521/ORCLPDB1
+> utplsql info app/app@localhost:1521/ORCLPDB1
 
-> cli 3.1.1-SNAPSHOT.local
-> utPLSQL-java-api 3.1.1-SNAPSHOT.123
-> utPLSQL 3.1.2.1913
+cli 3.1.1-SNAPSHOT.local
+utPLSQL-java-api 3.1.1-SNAPSHOT.123
+utPLSQL 3.1.2.1913
 ```
 
+### reporters
+`utplsql info <ConnectionURL>`
+
+```
+<ConnectionURL>     - accepted formats:
+                        <user>/<password>@//<host>[:<port>]/<service>
+                        <user>/<password>@<host>:<port>:<SID> 
+                        <user>/<password>@<TNSName> 
+                      To connect using TNS, you need to have the ORACLE_HOME environment variable set.
+                      The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
+                      The file tnsnames.ora must contain valid TNS entries. 
+```
+
+#### Examples
+```
+> utplsql reporters app/app@localhost:1521/ORCLPDB1
+
+UT_COVERAGE_COBERTURA_REPORTER (SQL): Generates a Cobertura coverage report providing information on code coverage with line numbers.
+Designed for Jenkins and TFS to report coverage. 
+Cobertura Document Type Definition can be found: http://cobertura.sourceforge.net/xml/coverage-04.dtd.
+Sample file: https://github.com/leobalter/testing-examples/blob/master/solutions/3/report/cobertura-coverage.xml.
+
+UT_COVERAGE_HTML_REPORTER (SQL_WITH_JAVA): Generates a HTML coverage report with summary and line by line information on code coverage.
+Based on open-source simplecov-html coverage reporter for Ruby.
+Includes source code in the report.
+Will copy all necessary assets to a folder named after the Output-File
+
+UT_COVERAGE_SONAR_REPORTER (SQL): Generates a JSON coverage report providing information on code coverage with line numbers.
+Designed for [SonarQube](https://about.sonarqube.com/) to report coverage.
+JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
+
+UT_COVERALLS_REPORTER (SQL): Generates a JSON coverage report providing information on code coverage with line numbers.
+Designed for [Coveralls](https://coveralls.io/).
+JSON format conforms with specification: https://docs.coveralls.io/api-introduction
+
+UT_DOCUMENTATION_REPORTER (SQL_WITH_JAVA): A textual pretty-print of unit test results (usually use for console output)
+Provides additional properties lvl and failed
+
+UT_JUNIT_REPORTER (SQL): Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
+
+UT_SONAR_TEST_REPORTER (SQL): Generates a JSON report providing detailed information on test execution.
+Designed for [SonarQube](https://about.sonarqube.com/) to report test execution.
+JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
+
+UT_TEAMCITY_REPORTER (SQL): Provides the TeamCity (a CI server by jetbrains) reporting-format that allows tracking of progress of a CI step/task as it executes.
+https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
+
+UT_TFS_JUNIT_REPORTER (SQL): Provides outcomes in a format conforming with JUnit version for TFS / VSTS.
+    As defined by specs :https://docs.microsoft.com/en-us/vsts/build-release/tasks/test/publish-test-results?view=vsts
+    Version is based on windy road junit https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd.
+
+UT_XUNIT_REPORTER (SQL): Depracated reporter. Please use Junit.
+    Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
+```
 
 ## Enabling Color Outputs on Windows
 

--- a/README.md
+++ b/README.md
@@ -162,42 +162,52 @@ utPLSQL 3.1.2.1913
 ```
 > utplsql reporters app/app@localhost:1521/ORCLPDB1
 
-UT_COVERAGE_COBERTURA_REPORTER Generates a Cobertura coverage report providing information on code coverage with line numbers.
-                               Designed for Jenkins and TFS to report coverage.
-                               Cobertura Document Type Definition can be found: http://cobertura.sourceforge.net/xml/coverage-04.dtd.
-                               Sample file: https://github.com/leobalter/testing-examples/blob/master/solutions/3/report/cobertura-coverage.xml.
+UT_COVERAGE_COBERTURA_REPORTER:
+    Generates a Cobertura coverage report providing information on code coverage with line numbers.
+    Designed for Jenkins and TFS to report coverage.
+    Cobertura Document Type Definition can be found: http://cobertura.sourceforge.net/xml/coverage-04.dtd.
+    Sample file: https://github.com/leobalter/testing-examples/blob/master/solutions/3/report/cobertura-coverage.xml.
 
-UT_COVERAGE_HTML_REPORTER      Generates a HTML coverage report with summary and line by line information on code coverage.
-                               Based on open-source simplecov-html coverage reporter for Ruby.
-                               Includes source code in the report.
-                               Will copy all necessary assets to a folder named after the Output-File
+UT_COVERAGE_HTML_REPORTER:
+    Generates a HTML coverage report with summary and line by line information on code coverage.
+    Based on open-source simplecov-html coverage reporter for Ruby.
+    Includes source code in the report.
+    Will copy all necessary assets to a folder named after the Output-File
 
-UT_COVERAGE_SONAR_REPORTER     Generates a JSON coverage report providing information on code coverage with line numbers.
-                               Designed for [SonarQube](https://about.sonarqube.com/) to report coverage.
-                               JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
+UT_COVERAGE_SONAR_REPORTER:
+    Generates a JSON coverage report providing information on code coverage with line numbers.
+    Designed for [SonarQube](https://about.sonarqube.com/) to report coverage.
+    JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
 
-UT_COVERALLS_REPORTER          Generates a JSON coverage report providing information on code coverage with line numbers.
-                               Designed for [Coveralls](https://coveralls.io/).
-                               JSON format conforms with specification: https://docs.coveralls.io/api-introduction
+UT_COVERALLS_REPORTER:
+    Generates a JSON coverage report providing information on code coverage with line numbers.
+    Designed for [Coveralls](https://coveralls.io/).
+    JSON format conforms with specification: https://docs.coveralls.io/api-introduction
 
-UT_DOCUMENTATION_REPORTER      A textual pretty-print of unit test results (usually use for console output)
-                               Provides additional properties lvl and failed
+UT_DOCUMENTATION_REPORTER:
+    A textual pretty-print of unit test results (usually use for console output)
+    Provides additional properties lvl and failed
 
-UT_JUNIT_REPORTER              Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
+UT_JUNIT_REPORTER:
+    Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
 
-UT_SONAR_TEST_REPORTER         Generates a JSON report providing detailed information on test execution.
-                               Designed for [SonarQube](https://about.sonarqube.com/) to report test execution.
-                               JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
+UT_SONAR_TEST_REPORTER:
+    Generates a JSON report providing detailed information on test execution.
+    Designed for [SonarQube](https://about.sonarqube.com/) to report test execution.
+    JSON format returned conforms with the Sonar specification: https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
 
-UT_TEAMCITY_REPORTER           Provides the TeamCity (a CI server by jetbrains) reporting-format that allows tracking of progress of a CI step/task as it executes.
-                               https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
+UT_TEAMCITY_REPORTER:
+    Provides the TeamCity (a CI server by jetbrains) reporting-format that allows tracking of progress of a CI step/task as it executes.
+    https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
 
-UT_TFS_JUNIT_REPORTER          Provides outcomes in a format conforming with JUnit version for TFS / VSTS.
-                               As defined by specs :https://docs.microsoft.com/en-us/vsts/build-release/tasks/test/publish-test-results?view=vsts
-                               Version is based on windy road junit https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd.
+UT_TFS_JUNIT_REPORTER:
+    Provides outcomes in a format conforming with JUnit version for TFS / VSTS.
+    As defined by specs :https://docs.microsoft.com/en-us/vsts/build-release/tasks/test/publish-test-results?view=vsts
+    Version is based on windy road junit https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd.
 
-UT_XUNIT_REPORTER              Depracated reporter. Please use Junit.
-                               Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
+UT_XUNIT_REPORTER:
+    Depracated reporter. Please use Junit.
+    Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
 ```
 
 ## Enabling Color Outputs on Windows

--- a/README.md
+++ b/README.md
@@ -39,17 +39,25 @@ export LC_ALL=en_US.utf-8
 The charset-part of LC_ALL is ignored.
 
 ## Usage
+Currently, utPLSQL-cli knows the following commands:
+- run
+- info
 
-`utplsql run <ConnectionURL> [-p=(ut_path|ut_paths)] [-f=format [-o=output_file] [-s] ...]`
-
+### run
+`utplsql run <ConnectionURL> [<options>]`
+                                                                 
 ```
 <ConnectionURL>     - accepted formats:
-                      <user>/<password>@//<host>[:<port>]/<service>
-                      <user>/<password>@<host>:<port>:<SID> 
-                      <user>/<password>@<TNSName> 
-                        To connect using TNS, you need to have the ORACLE_HOME environment variable set.
-                        The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
-                        The file tnsnames.ora must contain valid TNS entries. 
+                        <user>/<password>@//<host>[:<port>]/<service>
+                        <user>/<password>@<host>:<port>:<SID> 
+                        <user>/<password>@<TNSName> 
+                      To connect using TNS, you need to have the ORACLE_HOME environment variable set.
+                      The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
+                      The file tnsnames.ora must contain valid TNS entries. 
+```
+
+#### Options
+```                       
 -p=suite_path(s)    - A suite path or a comma separated list of suite paths for unit test to be executed.     
                       The path(s) can be in one of the following formats:
                           schema[.package[.procedure]]
@@ -57,66 +65,54 @@ The charset-part of LC_ALL is ignored.
                       Both formats can be mixed in the list.
                       If only schema is provided, then all suites owner by that schema are executed.
                       If -p is omitted, the current schema is used.
+                      
 -f=format           - A reporter to be used for reporting.
                       If no -f option is provided, the default ut_documentation_reporter is used.
-                      Available options:
-                          -f=ut_documentation_reporter
-                             A textual pretty-print of unit test results (usually use for console output)
-                          -f=ut_teamcity_reporter
-                             For reporting live progress of test execution with Teamcity CI. 
-                          -f=ut_xunit_reporter
-                             Used for reporting test results with CI servers like Jenkins/Hudson/Teamcity.
-                          -f=ut_coverage_html_reporter
-                             Generates a HTML coverage report with summary and line by line information on code coverage.
-                             Based on open-source simplecov-html coverage reporter for Ruby.
-                             Includes source code in the report.
-                          -f=ut_coveralls_reporter
-                             Generates a JSON coverage report providing information on code coverage with line numbers.
-                             Designed for [Coveralls](https://coveralls.io/).
-                          -f=ut_coverage_sonar_reporter
-                             Generates a JSON coverage report providing information on code coverage with line numbers.
-                             Designed for [SonarQube](https://about.sonarqube.com/) to report coverage.
-                          -f=ut_sonar_test_reporter
-                             Generates a JSON report providing detailed information on test execution.
-                             Designed for [SonarQube](https://about.sonarqube.com/) to report test execution.
-  
-    -o=output       - Defines file name to save the output from the specified reporter.
+                      See reporters list for possible values
+  -o=output         - Defines file name to save the output from the specified reporter.
                       If defined, the output is not displayed on screen by default. This can be changed with the -s parameter.
                       If not defined, then output will be displayed on screen, even if the parameter -s is not specified.
                       If more than one -o parameter is specified for one -f parameter, the last one is taken into consideration.
-    -s              - Forces putting output to to screen for a given -f parameter.
+  -s                - Forces putting output to to screen for a given -f parameter.
+  
 -source_path=source - path to project source files, use the following options to enable custom type mappings:
-    -owner="app"
-    -regex_expression="pattern"
-    -type_mapping="matched_string=TYPE[/matched_string=TYPE]*"
-    -owner_subexpression=subexpression_number
-    -type_subexpression=subexpression_number
-    -name_subexpression=subexpression_number
+  -owner="app"
+  -regex_expression="pattern"
+  -type_mapping="matched_string=TYPE[/matched_string=TYPE]*"
+  -owner_subexpression=subexpression_number
+  -type_subexpression=subexpression_number
+  -name_subexpression=subexpression_number
+  
 -test_path=test     - path to project test files, use the following options to enable custom type mappings:
-    -owner="app"
-    -regex_expression="pattern"
-    -type_mapping="matched_string=TYPE[/matched_string=TYPE]*"
-    -owner_subexpression=subexpression_number
-    -type_subexpression=subexpression_number
-    -name_subexpression=subexpression_number
+  -owner="app"
+  -regex_expression="pattern"
+  -type_mapping="matched_string=TYPE[/matched_string=TYPE]*"
+  -owner_subexpression=subexpression_number
+  -type_subexpression=subexpression_number
+  -name_subexpression=subexpression_number
+    
 -c                  - If specified, enables printing of test results in colors as defined by ANSICONSOLE standards. 
                       Works only on reporeters that support colors (ut_documentation_reporter).
+                      
 --failure-exit-code - Override the exit code on failure, defaults to 1. You can set it to 0 to always exit with a success status.
+
 -scc                - If specified, skips the compatibility-check with the version of the database framework.
                       If you skip compatibility-check, CLI will expect the most actual framework version
--include=package_list - Comma-separated object list to include in the coverage report.
-                        Format: [schema.]package[,[schema.]package ...].
-                        See coverage reporting options in framework documentation.
--exclude=package_list - Comma-separated object list to exclude from the coverage report.
-                        Format: [schema.]package[,[schema.]package ...].
-                        See coverage reporting options in framework documentation.
+                      
+-include=pckg_list  - Comma-separated object list to include in the coverage report.
+                      Format: [schema.]package[,[schema.]package ...].
+                      See coverage reporting options in framework documentation.
+                      
+-exclude=pckg_list  - Comma-separated object list to exclude from the coverage report.
+                      Format: [schema.]package[,[schema.]package ...].
+                      See coverage reporting options in framework documentation.
 ```
 
 Parameters -f, -o, -s are correlated. That is parameters -o and -s are controlling outputs for reporter specified by the preceding -f parameter.
 
 Sonar and Coveralls reporter will only provide valid reports, when source_path and/or test_path are provided, and ut_run is executed from your project's root path.
 
-Examples:
+#### Examples
 
 ```
 utplsql run hr/hr@xe -p=hr_test -f=ut_documentation_reporter -o=run.log -s -f=ut_coverage_html_reporter -o=coverage.html -source_path=source
@@ -133,7 +129,37 @@ utplsql run hr/hr@xe
 
 Invokes all unit test suites from schema "hr". Results are displayed to screen using default ut_documentation_reporter.
 
-#### Enabling Color Outputs on Windows
+### info
+`utplsql info [<ConnectionURL>]`
+
+```
+<ConnectionURL>     - accepted formats:
+                        <user>/<password>@//<host>[:<port>]/<service>
+                        <user>/<password>@<host>:<port>:<SID> 
+                        <user>/<password>@<TNSName> 
+                      To connect using TNS, you need to have the ORACLE_HOME environment variable set.
+                      The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
+                      The file tnsnames.ora must contain valid TNS entries. 
+```
+
+#### Examples
+
+```
+utplsql info
+
+> cli 3.1.1-SNAPSHOT.local
+> utPLSQL-java-api 3.1.1-SNAPSHOT.123
+```
+```
+utplsql info app/app@localhost:1521/ORCLPDB1
+
+> cli 3.1.1-SNAPSHOT.local
+> utPLSQL-java-api 3.1.1-SNAPSHOT.123
+> utPLSQL 3.1.2.1913
+```
+
+
+## Enabling Color Outputs on Windows
 
 To enable color outputs on Windows cmd you need to install an open-source utility called [ANSICON](http://adoxa.altervista.org/ansicon/).
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.platform.version>1.0.3</junit.platform.version>
         <junit.jupiter.version>5.0.3</junit.jupiter.version>
+        <travisBuildNumber>local</travisBuildNumber>
     </properties>
 
   <dependencies>
@@ -88,6 +89,41 @@
           </programs>
         </configuration>
       </plugin>
+        <plugin>
+            <groupId>com.google.code.maven-replacer-plugin</groupId>
+            <artifactId>replacer</artifactId>
+            <version>1.5.3</version>
+            <executions>
+                <execution>
+                    <id>replace-version-number</id>
+                    <phase>generate-sources</phase>
+                    <goals>
+                        <goal>replace</goal>
+                    </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <basedir>${project.basedir}/src/main/java</basedir>
+                <includes>
+                    <include>**/CliVersionInfo.java</include>
+                </includes>
+                <preserveDir>true</preserveDir>
+                <replacements>
+                    <replacement>
+                        <token>MAVEN_PROJECT_NAME = ".*"</token>
+                        <value>MAVEN_PROJECT_NAME = "${project.name}"</value>
+                    </replacement>
+                    <replacement>
+                        <token>MAVEN_PROJECT_VERSION = ".*"</token>
+                        <value>MAVEN_PROJECT_VERSION = "${project.version}"</value>
+                    </replacement>
+                    <replacement>
+                        <token>BUILD_NO = ".*"</token>
+                        <value>BUILD_NO = "${travisBuildNumber}"</value>
+                    </replacement>
+                </replacements>
+            </configuration>
+        </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/org/utplsql/cli/Cli.java
+++ b/src/main/java/org/utplsql/cli/Cli.java
@@ -13,6 +13,7 @@ public class Cli {
 
     static final String HELP_CMD = "-h";
     private static final String RUN_CMD = "run";
+    private static final String VERSION_CMD = "info";
 
     public static void main(String[] args) {
 
@@ -22,8 +23,9 @@ public class Cli {
         jc.setProgramName("utplsql");
         // jc.addCommand(HELP_CMD, new HelpCommand());
         RunCommand runCmd = new RunCommand();
+        VersionInfoCommand infoCmd = new VersionInfoCommand();
         jc.addCommand(RUN_CMD, runCmd);
-
+        jc.addCommand(VERSION_CMD, infoCmd);
         int exitCode = DEFAULT_ERROR_CODE;
 
         try {
@@ -31,7 +33,11 @@ public class Cli {
 
             if (RUN_CMD.equals(jc.getParsedCommand())) {
                 exitCode = runCmd.run();
-            } else {
+            }
+            else if ( VERSION_CMD.equals(jc.getParsedCommand()) ) {
+                exitCode = infoCmd.run();
+            }
+            else {
                 throw new ParameterException("Command not specified.");
             }
         } catch (ParameterException e) {

--- a/src/main/java/org/utplsql/cli/CliVersionInfo.java
+++ b/src/main/java/org/utplsql/cli/CliVersionInfo.java
@@ -1,0 +1,20 @@
+package org.utplsql.cli;
+
+/** This class is getting updated automatically by the build process.
+ * Please do not update its constants manually cause they will be overwritten.
+ *
+ * @author pesse
+ */
+public class CliVersionInfo {
+
+    private static final String BUILD_NO = "local";
+    private static final String MAVEN_PROJECT_NAME = "cli";
+    private static final String MAVEN_PROJECT_VERSION = "3.1.1-SNAPSHOT";
+
+    public static String getVersion() {
+        return MAVEN_PROJECT_VERSION + "." + BUILD_NO;
+    }
+
+    public static String getInfo() { return MAVEN_PROJECT_NAME + " " + getVersion(); }
+
+}

--- a/src/main/java/org/utplsql/cli/CommandProvider.java
+++ b/src/main/java/org/utplsql/cli/CommandProvider.java
@@ -1,0 +1,36 @@
+package org.utplsql.cli;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class CommandProvider {
+
+    private Map<String, ICommand> commands;
+
+    public CommandProvider() {
+        init();
+    }
+
+    private void init() {
+        commands = new HashMap<>();
+
+        addCommand(new RunCommand());
+        addCommand(new VersionInfoCommand());
+    }
+
+    private void addCommand( ICommand command ) {
+        commands.put(command.getCommand().toLowerCase(), command);
+    }
+
+    public ICommand getCommand( String key ) {
+        if ( commands.containsKey(key))
+            return commands.get(key.toLowerCase());
+        else
+            return new HelpCommand("Unknown command: '" + key + "'");
+    }
+
+    public Stream<ICommand> commands() {
+        return commands.values().stream();
+    }
+}

--- a/src/main/java/org/utplsql/cli/CommandProvider.java
+++ b/src/main/java/org/utplsql/cli/CommandProvider.java
@@ -17,6 +17,7 @@ public class CommandProvider {
 
         addCommand(new RunCommand());
         addCommand(new VersionInfoCommand());
+        addCommand(new ReportersCommand());
     }
 
     private void addCommand( ICommand command ) {

--- a/src/main/java/org/utplsql/cli/ConnectionInfo.java
+++ b/src/main/java/org/utplsql/cli/ConnectionInfo.java
@@ -1,40 +1,18 @@
 package org.utplsql.cli;
 
 import com.beust.jcommander.IStringConverter;
-import com.zaxxer.hikari.HikariDataSource;
-
-import java.io.File;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 
 public class ConnectionInfo {
 
-    private String databaseVersion;
-
-    static {
-        String oracleHome = System.getenv("ORACLE_HOME");
-        if (oracleHome != null) {
-            System.setProperty("oracle.net.tns_admin",
-                    String.join(File.separator, oracleHome, "NETWORK", "ADMIN"));
-        }
-    }
-
-    private HikariDataSource pds = new HikariDataSource();
+    public static final String COMMANDLINE_PARAM_DESCRIPTION = "<user>/<password>@//<host>[:<port>]/<service> OR <user>/<password>@<TNSName> OR <user>/<password>@<host>:<port>:<SID>";
+    private String connectionInfo;
 
     public ConnectionInfo(String connectionInfo) {
-
-        pds.setJdbcUrl("jdbc:oracle:thin:" + connectionInfo);
-        pds.setAutoCommit(false);
+        this.connectionInfo = connectionInfo;
     }
 
-    public void setMaxConnections( int maxConnections ) {
-        pds.setMaximumPoolSize(maxConnections);
-    }
-
-    public Connection getConnection() throws SQLException {
-        return pds.getConnection();
+    public String getConnectionString() {
+        return connectionInfo;
     }
 
     public static class ConnectionStringConverter implements IStringConverter<ConnectionInfo> {
@@ -44,41 +22,4 @@ public class ConnectionInfo {
             return new ConnectionInfo(s);
         }
     }
-
-    public String getOracleDatabaseVersion() throws SQLException
-    {
-        try ( Connection conn = getConnection() ) {
-            return getOracleDatabaseVersion(conn);
-        }
-    }
-
-    public String getOracleDatabaseVersion( Connection conn ) throws SQLException
-    {
-        if ( databaseVersion == null ) {
-            databaseVersion = getOracleDatabaseVersionFromConnection( conn );
-        }
-
-        return databaseVersion;
-    }
-
-    /** TODO: Outsource this to Java-API
-     *
-     * @param conn
-     * @return
-     * @throws SQLException
-     */
-    public static String getOracleDatabaseVersionFromConnection( Connection conn ) throws SQLException {
-        assert conn != null;
-        String result = null;
-        try (PreparedStatement stmt = conn.prepareStatement("select version from product_component_version where product like 'Oracle Database%'"))
-        {
-            ResultSet rs = stmt.executeQuery();
-
-            if ( rs.next() )
-                result = rs.getString(1);
-        }
-
-        return result;
-    }
-
 }

--- a/src/main/java/org/utplsql/cli/DataSourceProvider.java
+++ b/src/main/java/org/utplsql/cli/DataSourceProvider.java
@@ -1,0 +1,44 @@
+package org.utplsql.cli;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.utplsql.api.EnvironmentVariableUtil;
+
+import javax.sql.DataSource;
+import java.io.File;
+
+/** Helper class to give you a ready-to-use datasource
+ *
+ * @author pesse
+ */
+public class DataSourceProvider {
+
+    static {
+        String oracleHome = EnvironmentVariableUtil.getEnvValue("ORACLE_HOME");
+        if (oracleHome != null) {
+            System.setProperty("oracle.net.tns_admin",
+                    String.join(File.separator, oracleHome, "NETWORK", "ADMIN"));
+        }
+    }
+
+    public static DataSource getDataSource(ConnectionInfo info, int maxConnections ) {
+
+        requireOjdbc();
+
+        HikariDataSource pds = new HikariDataSource();
+        pds.setJdbcUrl("jdbc:oracle:thin:" + info.getConnectionString());
+        pds.setAutoCommit(false);
+        pds.setMaximumPoolSize(maxConnections);
+        return pds;
+    }
+
+    private static void requireOjdbc() {
+        if ( !OracleLibraryChecker.checkOjdbcExists() )
+        {
+            System.out.println("Could not find Oracle JDBC driver in classpath. Please download the jar from Oracle website" +
+                    " and copy it to the 'lib' folder of your utPLSQL-cli installation.");
+            System.out.println("Download from http://www.oracle.com/technetwork/database/features/jdbc/jdbc-ucp-122-3110062.html");
+
+            throw new RuntimeException("Can't run utPLSQL-cli without Oracle JDBC driver");
+        }
+    }
+}

--- a/src/main/java/org/utplsql/cli/HelpCommand.java
+++ b/src/main/java/org/utplsql/cli/HelpCommand.java
@@ -1,0 +1,23 @@
+package org.utplsql.cli;
+
+public class HelpCommand implements ICommand {
+
+    private String errorMessage;
+
+    public HelpCommand( String errorMessage ) {
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public int run() {
+        if ( errorMessage != null )
+            System.out.println(errorMessage);
+
+        return 1;
+    }
+
+    @Override
+    public String getCommand() {
+        return "-h";
+    }
+}

--- a/src/main/java/org/utplsql/cli/ICommand.java
+++ b/src/main/java/org/utplsql/cli/ICommand.java
@@ -1,0 +1,11 @@
+package org.utplsql.cli;
+
+/** Interface to decouple JCommander commands
+ *
+ * @author pesse
+ */
+public interface ICommand {
+    int run();
+
+    String getCommand();
+}

--- a/src/main/java/org/utplsql/cli/ReporterFactoryProvider.java
+++ b/src/main/java/org/utplsql/cli/ReporterFactoryProvider.java
@@ -5,6 +5,9 @@ import org.utplsql.api.reporter.CoreReporters;
 import org.utplsql.api.reporter.ReporterFactory;
 import org.utplsql.cli.reporters.LocalAssetsCoverageHTMLReporter;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+
 /** A simple class to provide a ReporterFactory for the RunCommand
  *
  * @author pesse
@@ -16,5 +19,9 @@ public class ReporterFactoryProvider {
         reporterFactory.registerReporterFactoryMethod(CoreReporters.UT_COVERAGE_HTML_REPORTER.name(), LocalAssetsCoverageHTMLReporter::new, "Will copy all necessary assets to a folder named after the Output-File");
 
         return reporterFactory;
+    }
+
+    public static ReporterFactory createReporterFactory(Connection con ) throws SQLException {
+        return createReporterFactory(new CompatibilityProxy(con));
     }
 }

--- a/src/main/java/org/utplsql/cli/ReporterManager.java
+++ b/src/main/java/org/utplsql/cli/ReporterManager.java
@@ -6,6 +6,7 @@ import org.utplsql.api.reporter.Reporter;
 import org.utplsql.api.reporter.ReporterFactory;
 import org.utplsql.cli.reporters.ReporterOptionsAware;
 
+import javax.sql.DataSource;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
@@ -77,10 +78,10 @@ class ReporterManager {
     /** Starts a separate thread for each Reporter to gather its results
      *
      * @param executorService
-     * @param ci
+     * @param dataSource
      * @param returnCode
      */
-    public void startReporterGatherers(ExecutorService executorService, final ConnectionInfo ci, final int[] returnCode)
+    public void startReporterGatherers(ExecutorService executorService, final DataSource dataSource, final int[] returnCode)
     {
         // TODO: Implement Init-check
         // Gather each reporter results on a separate thread.
@@ -89,7 +90,7 @@ class ReporterManager {
                 List<PrintStream> printStreams = new ArrayList<>();
                 PrintStream fileOutStream = null;
 
-                try (Connection conn = ci.getConnection()) {
+                try (Connection conn = dataSource.getConnection()) {
                     if (ro.outputToScreen()) {
                         printStreams.add(System.out);
                         ro.getReporterObj().getOutputBuffer().setFetchSize(1);

--- a/src/main/java/org/utplsql/cli/ReportersCommand.java
+++ b/src/main/java/org/utplsql/cli/ReportersCommand.java
@@ -2,16 +2,14 @@ package org.utplsql.cli;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import org.utplsql.api.compatibility.CompatibilityProxy;
 import org.utplsql.api.reporter.ReporterFactory;
 import org.utplsql.api.reporter.inspect.ReporterInfo;
 import org.utplsql.api.reporter.inspect.ReporterInspector;
 
 import javax.sql.DataSource;
+import java.io.PrintStream;
 import java.sql.Connection;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 @Parameters(separators = "=", commandDescription = "prints a list of reporters available in the specified database")
 public class ReportersCommand implements ICommand {
@@ -37,12 +35,7 @@ public class ReportersCommand implements ICommand {
 
             ReporterFactory reporterFactory = ReporterFactoryProvider.createReporterFactory(con);
 
-            ReporterInspector.create(reporterFactory, con).getReporterInfos().stream()
-                    .sorted(Comparator.comparing(ReporterInfo::getName))
-                    .forEach(r -> {
-                        System.out.println(r.getName() + " (" + r.getType().name() + "): " + r.getDescription());
-                        System.out.println();
-                    });
+            writeReporters(ReporterInspector.create(reporterFactory, con).getReporterInfos(), System.out);
         }
         catch ( Exception e ) {
             e.printStackTrace();
@@ -55,5 +48,48 @@ public class ReportersCommand implements ICommand {
     @Override
     public String getCommand() {
         return "reporters";
+    }
+
+    private int getMaxNameLength(List<ReporterInfo> reporterInfos) {
+        return reporterInfos.stream()
+                .mapToInt(info -> info.getName().length())
+                .max()
+                .orElse(0);
+    }
+
+    private void writeReporters(List<ReporterInfo> reporterInfos, PrintStream out) {
+        int padding = getMaxNameLength(reporterInfos)+1;
+        reporterInfos.stream()
+                .sorted(Comparator.comparing(ReporterInfo::getName))
+                .forEach(info -> writeReporter(info, padding, out));
+    }
+
+    private void writeReporter(ReporterInfo info, int padding, PrintStream out) {
+
+        writeReporterName(info, padding, out);
+        writeReporterDescription(info, padding, out);
+
+        out.println();
+    }
+
+    private void writeReporterName( ReporterInfo info, int paddingRight, PrintStream out ) {
+        out.print(String.format("%1$-" + paddingRight + "s", info.getName()));
+    }
+
+    private void writeReporterDescription( ReporterInfo info, int paddingLeft, PrintStream out ) {
+        String[] lines = info.getDescription().split("\n");
+
+        boolean firstLine = true;
+        for ( String line : lines ) {
+
+            line = line.trim();
+
+            if ( !firstLine )
+                out.print(String.format("%1$" + paddingLeft + "s", ""));
+
+            out.println(line);
+            firstLine = false;
+        }
+
     }
 }

--- a/src/main/java/org/utplsql/cli/ReportersCommand.java
+++ b/src/main/java/org/utplsql/cli/ReportersCommand.java
@@ -20,11 +20,12 @@ public class ReportersCommand implements ICommand {
             description = ConnectionInfo.COMMANDLINE_PARAM_DESCRIPTION)
     private List<ConnectionInfo> connectionInfoList = new ArrayList<>();
 
-    public ConnectionInfo getConnectionInfo() {
-        if ( connectionInfoList != null && connectionInfoList.size() > 0 )
-            return connectionInfoList.get(0);
-        else
-            return null;
+    private ConnectionInfo getConnectionInfo() {
+        assert connectionInfoList != null;
+        assert connectionInfoList.size() > 0;
+        assert connectionInfoList.get(0) != null;
+
+        return connectionInfoList.get(0);
     }
 
     @Override

--- a/src/main/java/org/utplsql/cli/ReportersCommand.java
+++ b/src/main/java/org/utplsql/cli/ReportersCommand.java
@@ -1,0 +1,59 @@
+package org.utplsql.cli;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import org.utplsql.api.compatibility.CompatibilityProxy;
+import org.utplsql.api.reporter.ReporterFactory;
+import org.utplsql.api.reporter.inspect.ReporterInfo;
+import org.utplsql.api.reporter.inspect.ReporterInspector;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Parameters(separators = "=", commandDescription = "prints a list of reporters available in the specified database")
+public class ReportersCommand implements ICommand {
+
+    @Parameter(
+            converter = ConnectionInfo.ConnectionStringConverter.class,
+            arity = 1,
+            description = ConnectionInfo.COMMANDLINE_PARAM_DESCRIPTION)
+    private List<ConnectionInfo> connectionInfoList = new ArrayList<>();
+
+    public ConnectionInfo getConnectionInfo() {
+        if ( connectionInfoList != null && connectionInfoList.size() > 0 )
+            return connectionInfoList.get(0);
+        else
+            return null;
+    }
+
+    @Override
+    public int run() {
+
+        DataSource ds = DataSourceProvider.getDataSource(getConnectionInfo(), 1);
+        try (Connection con = ds.getConnection() ) {
+
+            ReporterFactory reporterFactory = ReporterFactoryProvider.createReporterFactory(con);
+
+            ReporterInspector.create(reporterFactory, con).getReporterInfos().stream()
+                    .sorted(Comparator.comparing(ReporterInfo::getName))
+                    .forEach(r -> {
+                        System.out.println(r.getName() + " (" + r.getType().name() + "): " + r.getDescription());
+                        System.out.println();
+                    });
+        }
+        catch ( Exception e ) {
+            e.printStackTrace();
+            return 1;
+        }
+
+        return 0;
+    }
+
+    @Override
+    public String getCommand() {
+        return "reporters";
+    }
+}

--- a/src/main/java/org/utplsql/cli/ReportersCommand.java
+++ b/src/main/java/org/utplsql/cli/ReportersCommand.java
@@ -59,10 +59,10 @@ public class ReportersCommand implements ICommand {
     }
 
     private void writeReporters(List<ReporterInfo> reporterInfos, PrintStream out) {
-        int padding = getMaxNameLength(reporterInfos)+1;
+        //int padding = getMaxNameLength(reporterInfos)+1;
         reporterInfos.stream()
                 .sorted(Comparator.comparing(ReporterInfo::getName))
-                .forEach(info -> writeReporter(info, padding, out));
+                .forEach(info -> writeReporter(info, 4, out));
     }
 
     private void writeReporter(ReporterInfo info, int padding, PrintStream out) {
@@ -74,23 +74,13 @@ public class ReportersCommand implements ICommand {
     }
 
     private void writeReporterName( ReporterInfo info, int paddingRight, PrintStream out ) {
-        out.print(String.format("%1$-" + paddingRight + "s", info.getName()));
+        out.println(info.getName()+":");
+
     }
 
     private void writeReporterDescription( ReporterInfo info, int paddingLeft, PrintStream out ) {
         String[] lines = info.getDescription().split("\n");
-
-        boolean firstLine = true;
-        for ( String line : lines ) {
-
-            line = line.trim();
-
-            if ( !firstLine )
-                out.print(String.format("%1$" + paddingLeft + "s", ""));
-
-            out.println(line);
-            firstLine = false;
-        }
-
+        String paddingLeftStr = String.format("%1$"+paddingLeft+"s", "");
+        Arrays.stream(lines).forEach(line -> out.println(paddingLeftStr+line.trim()));
     }
 }

--- a/src/main/java/org/utplsql/cli/RunCommand.java
+++ b/src/main/java/org/utplsql/cli/RunCommand.java
@@ -7,7 +7,9 @@ import org.utplsql.api.KeyValuePair;
 import org.utplsql.api.TestRunner;
 import org.utplsql.api.Version;
 import org.utplsql.api.compatibility.CompatibilityProxy;
+import org.utplsql.api.exception.DatabaseNotCompatibleException;
 import org.utplsql.api.exception.SomeTestsFailedException;
+import org.utplsql.api.exception.UtPLSQLNotInstalledException;
 import org.utplsql.api.reporter.Reporter;
 import org.utplsql.api.reporter.ReporterFactory;
 import org.utplsql.cli.exception.DatabaseConnectionFailed;
@@ -30,7 +32,7 @@ import java.util.concurrent.TimeUnit;
  * @author pesse
  */
 @Parameters(separators = "=", commandDescription = "run tests")
-public class RunCommand {
+public class RunCommand implements ICommand {
 
     @Parameter(
             required = true,
@@ -110,102 +112,113 @@ public class RunCommand {
         return testPaths;
     }
 
-    public int run() throws Exception {
+    public int run() {
 
-        final List<Reporter> reporterList;
-        final List<String> testPaths = getTestPaths();
+        try {
 
-        final File baseDir = new File("").getAbsoluteFile();
-        final FileMapperOptions[] sourceMappingOptions = {null};
-        final FileMapperOptions[] testMappingOptions = {null};
+            final List<Reporter> reporterList;
+            final List<String> testPaths = getTestPaths();
 
-        final int[] returnCode = {0};
+            final File baseDir = new File("").getAbsoluteFile();
+            final FileMapperOptions[] sourceMappingOptions = {null};
+            final FileMapperOptions[] testMappingOptions = {null};
 
-        sourceMappingOptions[0] = getFileMapperOptionsByParamListItem(this.sourcePathParams, baseDir);
-        testMappingOptions[0] = getFileMapperOptionsByParamListItem(this.testPathParams, baseDir);
+            final int[] returnCode = {0};
 
-        ArrayList<String> includeObjectsList;
-        ArrayList<String> excludeObjectsList;
+            sourceMappingOptions[0] = getFileMapperOptionsByParamListItem(this.sourcePathParams, baseDir);
+            testMappingOptions[0] = getFileMapperOptionsByParamListItem(this.testPathParams, baseDir);
 
-        if (includeObjects != null && !includeObjects.isEmpty()) {
-            includeObjectsList = new ArrayList<>(Arrays.asList(includeObjects.split(",")));
-        } else {
-            includeObjectsList = new ArrayList<>();
-        }
+            ArrayList<String> includeObjectsList;
+            ArrayList<String> excludeObjectsList;
 
-        if (excludeObjects != null && !excludeObjects.isEmpty()) {
-            excludeObjectsList = new ArrayList<>(Arrays.asList(excludeObjects.split(",")));
-        } else {
-            excludeObjectsList = new ArrayList<>();
-        }
-
-        final ArrayList<String> finalIncludeObjectsList = includeObjectsList;
-        final ArrayList<String> finalExcludeObjectsList = excludeObjectsList;
-
-        final DataSource dataSource = DataSourceProvider.getDataSource(getConnectionInfo(), getReporterManager().getNumberOfReporters()+1);
-
-        // Do the reporters initialization, so we can use the id to run and gather results.
-        try (Connection conn = dataSource.getConnection()) {
-
-            // Check if orai18n exists if database version is 11g
-            RunCommandChecker.checkOracleI18nExists(conn);
-
-            // First of all do a compatibility check and fail-fast
-            compatibilityProxy = checkFrameworkCompatibility(conn);
-            reporterFactory = ReporterFactoryProvider.createReporterFactory(compatibilityProxy);
-
-            reporterList = getReporterManager().initReporters(conn, reporterFactory, compatibilityProxy);
-
-        } catch (SQLException e) {
-            if ( e.getErrorCode() == 1017 || e.getErrorCode() == 12514 ) {
-                throw new DatabaseConnectionFailed(e);
+            if (includeObjects != null && !includeObjects.isEmpty()) {
+                includeObjectsList = new ArrayList<>(Arrays.asList(includeObjects.split(",")));
+            } else {
+                includeObjectsList = new ArrayList<>();
             }
-            else {
-                throw e;
+
+            if (excludeObjects != null && !excludeObjects.isEmpty()) {
+                excludeObjectsList = new ArrayList<>(Arrays.asList(excludeObjects.split(",")));
+            } else {
+                excludeObjectsList = new ArrayList<>();
             }
-        }
 
-        // Output a message if --failureExitCode is set but database framework is not capable of
-        String msg = RunCommandChecker.getCheckFailOnErrorMessage(failureExitCode, compatibilityProxy.getDatabaseVersion());
-        if ( msg != null ) {
-            System.out.println(msg);
-        }
+            final ArrayList<String> finalIncludeObjectsList = includeObjectsList;
+            final ArrayList<String> finalExcludeObjectsList = excludeObjectsList;
 
-        ExecutorService executorService = Executors.newFixedThreadPool(1 + reporterList.size());
+            final DataSource dataSource = DataSourceProvider.getDataSource(getConnectionInfo(), getReporterManager().getNumberOfReporters() + 1);
 
-        // Run tests.
-        executorService.submit(() -> {
+            // Do the reporters initialization, so we can use the id to run and gather results.
             try (Connection conn = dataSource.getConnection()) {
-                TestRunner testRunner = new TestRunner()
-                        .addPathList(testPaths)
-                        .addReporterList(reporterList)
-                        .sourceMappingOptions(sourceMappingOptions[0])
-                        .testMappingOptions(testMappingOptions[0])
-                        .colorConsole(this.colorConsole)
-                        .failOnErrors(true)
-                        .skipCompatibilityCheck(skipCompatibilityCheck)
-                        .includeObjects(finalIncludeObjectsList)
-                        .excludeObjects(finalExcludeObjectsList);
 
-                testRunner.run(conn);
-            } catch (SomeTestsFailedException e) {
-                returnCode[0] = this.failureExitCode;
+                // Check if orai18n exists if database version is 11g
+                RunCommandChecker.checkOracleI18nExists(conn);
+
+                // First of all do a compatibility check and fail-fast
+                compatibilityProxy = checkFrameworkCompatibility(conn);
+                reporterFactory = ReporterFactoryProvider.createReporterFactory(compatibilityProxy);
+
+                reporterList = getReporterManager().initReporters(conn, reporterFactory, compatibilityProxy);
+
             } catch (SQLException e) {
-                System.out.println(e.getMessage());
-                returnCode[0] = Cli.DEFAULT_ERROR_CODE;
-                executorService.shutdownNow();
+                if (e.getErrorCode() == 1017 || e.getErrorCode() == 12514) {
+                    throw new DatabaseConnectionFailed(e);
+                } else {
+                    throw e;
+                }
             }
-        });
 
-        // Gather each reporter results on a separate thread.
-        getReporterManager().startReporterGatherers(executorService, dataSource, returnCode);
+            // Output a message if --failureExitCode is set but database framework is not capable of
+            String msg = RunCommandChecker.getCheckFailOnErrorMessage(failureExitCode, compatibilityProxy.getDatabaseVersion());
+            if (msg != null) {
+                System.out.println(msg);
+            }
 
-        executorService.shutdown();
-        executorService.awaitTermination(60, TimeUnit.MINUTES);
-        return returnCode[0];
+            ExecutorService executorService = Executors.newFixedThreadPool(1 + reporterList.size());
+
+            // Run tests.
+            executorService.submit(() -> {
+                try (Connection conn = dataSource.getConnection()) {
+                    TestRunner testRunner = new TestRunner()
+                            .addPathList(testPaths)
+                            .addReporterList(reporterList)
+                            .sourceMappingOptions(sourceMappingOptions[0])
+                            .testMappingOptions(testMappingOptions[0])
+                            .colorConsole(this.colorConsole)
+                            .failOnErrors(true)
+                            .skipCompatibilityCheck(skipCompatibilityCheck)
+                            .includeObjects(finalIncludeObjectsList)
+                            .excludeObjects(finalExcludeObjectsList);
+
+                    testRunner.run(conn);
+                } catch (SomeTestsFailedException e) {
+                    returnCode[0] = this.failureExitCode;
+                } catch (SQLException e) {
+                    System.out.println(e.getMessage());
+                    returnCode[0] = Cli.DEFAULT_ERROR_CODE;
+                    executorService.shutdownNow();
+                }
+            });
+
+            // Gather each reporter results on a separate thread.
+            getReporterManager().startReporterGatherers(executorService, dataSource, returnCode);
+
+            executorService.shutdown();
+            executorService.awaitTermination(60, TimeUnit.MINUTES);
+            return returnCode[0];
+        }
+        catch ( DatabaseNotCompatibleException | UtPLSQLNotInstalledException | DatabaseConnectionFailed e ) {
+            System.out.println(e.getMessage());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return 1;
     }
 
-
+    @Override
+    public String getCommand() {
+        return "run";
+    }
 
 
     /** Returns FileMapperOptions for the first item of a given param list in a baseDir

--- a/src/main/java/org/utplsql/cli/RunCommandChecker.java
+++ b/src/main/java/org/utplsql/cli/RunCommandChecker.java
@@ -1,7 +1,11 @@
 package org.utplsql.cli;
 
+import org.utplsql.api.DBHelper;
 import org.utplsql.api.Version;
 import org.utplsql.api.compatibility.OptionalFeatures;
+
+import java.sql.Connection;
+import java.sql.SQLException;
 
 /** Helper class to check several circumstances with RunCommand. Might need refactoring.
  *
@@ -9,26 +13,12 @@ import org.utplsql.api.compatibility.OptionalFeatures;
  */
 class RunCommandChecker {
 
-    /** Checks that ojdbc library exists
-     *
-     */
-    static void checkOracleJDBCExists()
-    {
-        if ( !OracleLibraryChecker.checkOjdbcExists() )
-        {
-            System.out.println("Could not find Oracle JDBC driver in classpath. Please download the jar from Oracle website" +
-                    " and copy it to the 'lib' folder of your utPLSQL-cli installation.");
-            System.out.println("Download from http://www.oracle.com/technetwork/database/features/jdbc/jdbc-ucp-122-3110062.html");
-
-            throw new RuntimeException("Can't run utPLSQL-cli without Oracle JDBC driver");
-        }
-    }
-
     /** Checks that orai18n library exists if database is an oracle 11
      *
      */
-    static void checkOracleI18nExists(String oracleDatabaseVersion )
-    {
+    static void checkOracleI18nExists(Connection con) throws SQLException {
+
+        String oracleDatabaseVersion = DBHelper.getOracleDatabaseVersion(con);
         if ( oracleDatabaseVersion.startsWith("11.") && !OracleLibraryChecker.checkOrai18nExists() )
         {
             System.out.println("Warning: Could not find Oracle i18n driver in classpath. Depending on the database charset " +

--- a/src/main/java/org/utplsql/cli/VersionInfoCommand.java
+++ b/src/main/java/org/utplsql/cli/VersionInfoCommand.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Parameters(separators = "=", commandDescription = "prints version information of cli, java-api and - if connection is given - database utPLSQL framework")
-public class VersionInfoCommand {
+public class VersionInfoCommand implements ICommand {
 
     @Parameter(
             converter = ConnectionInfo.ConnectionStringConverter.class,
@@ -53,5 +53,10 @@ public class VersionInfoCommand {
         }
 
         return 0;
+    }
+
+    @Override
+    public String getCommand() {
+        return "info";
     }
 }

--- a/src/main/java/org/utplsql/cli/VersionInfoCommand.java
+++ b/src/main/java/org/utplsql/cli/VersionInfoCommand.java
@@ -8,6 +8,7 @@ import org.utplsql.api.JavaApiVersionInfo;
 import org.utplsql.api.Version;
 import org.utplsql.api.exception.UtPLSQLNotInstalledException;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +19,7 @@ public class VersionInfoCommand {
     @Parameter(
             converter = ConnectionInfo.ConnectionStringConverter.class,
             variableArity = true,
-            description = "<user>/<password>@//<host>[:<port>]/<service> OR <user>/<password>@<TNSName> OR <user>/<password>@<host>:<port>:<SID>")
+            description = ConnectionInfo.COMMANDLINE_PARAM_DESCRIPTION)
     private List<ConnectionInfo> connectionInfoList = new ArrayList<>();
 
     public ConnectionInfo getConnectionInfo() {
@@ -28,16 +29,17 @@ public class VersionInfoCommand {
             return null;
     }
 
-    public int run() throws Exception {
+    public int run() {
 
         System.out.println(CliVersionInfo.getInfo());
-        System.out.println("Java-API " + JavaApiVersionInfo.getVersion());
+        System.out.println(JavaApiVersionInfo.getInfo());
 
         ConnectionInfo ci = getConnectionInfo();
         if ( ci != null ) {
-            // TODO: Ora-check
-            ci.setMaxConnections(1);
-            try (Connection con = ci.getConnection()) {
+
+            DataSource dataSource = DataSourceProvider.getDataSource(ci, 1);
+
+            try (Connection con = dataSource.getConnection()) {
                 Version v = DBHelper.getDatabaseFrameworkVersion( con );
                 System.out.println("utPLSQL " + v.getNormalizedString());
             }

--- a/src/main/java/org/utplsql/cli/VersionInfoCommand.java
+++ b/src/main/java/org/utplsql/cli/VersionInfoCommand.java
@@ -1,0 +1,55 @@
+package org.utplsql.cli;
+
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import org.utplsql.api.DBHelper;
+import org.utplsql.api.JavaApiVersionInfo;
+import org.utplsql.api.Version;
+import org.utplsql.api.exception.UtPLSQLNotInstalledException;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+
+@Parameters(separators = "=", commandDescription = "prints version information of cli, java-api and - if connection is given - database utPLSQL framework")
+public class VersionInfoCommand {
+
+    @Parameter(
+            converter = ConnectionInfo.ConnectionStringConverter.class,
+            variableArity = true,
+            description = "<user>/<password>@//<host>[:<port>]/<service> OR <user>/<password>@<TNSName> OR <user>/<password>@<host>:<port>:<SID>")
+    private List<ConnectionInfo> connectionInfoList = new ArrayList<>();
+
+    public ConnectionInfo getConnectionInfo() {
+        if ( connectionInfoList != null && connectionInfoList.size() > 0 )
+            return connectionInfoList.get(0);
+        else
+            return null;
+    }
+
+    public int run() throws Exception {
+
+        System.out.println(CliVersionInfo.getInfo());
+        System.out.println("Java-API " + JavaApiVersionInfo.getVersion());
+
+        ConnectionInfo ci = getConnectionInfo();
+        if ( ci != null ) {
+            // TODO: Ora-check
+            ci.setMaxConnections(1);
+            try (Connection con = ci.getConnection()) {
+                Version v = DBHelper.getDatabaseFrameworkVersion( con );
+                System.out.println("utPLSQL " + v.getNormalizedString());
+            }
+            catch ( UtPLSQLNotInstalledException e ) {
+                System.out.println("utPLSQL framework is not installed in database.");
+            }
+            catch ( Exception e ) {
+                e.printStackTrace();
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/main/java/org/utplsql/cli/VersionInfoCommand.java
+++ b/src/main/java/org/utplsql/cli/VersionInfoCommand.java
@@ -10,6 +10,7 @@ import org.utplsql.api.exception.UtPLSQLNotInstalledException;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +35,18 @@ public class VersionInfoCommand implements ICommand {
         System.out.println(CliVersionInfo.getInfo());
         System.out.println(JavaApiVersionInfo.getInfo());
 
-        ConnectionInfo ci = getConnectionInfo();
+        try {
+            writeUtPlsqlVersion(getConnectionInfo());
+        }
+        catch (SQLException e) {
+            e.printStackTrace();
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private void writeUtPlsqlVersion( ConnectionInfo ci ) throws SQLException {
         if ( ci != null ) {
 
             DataSource dataSource = DataSourceProvider.getDataSource(ci, 1);
@@ -46,13 +58,7 @@ public class VersionInfoCommand implements ICommand {
             catch ( UtPLSQLNotInstalledException e ) {
                 System.out.println("utPLSQL framework is not installed in database.");
             }
-            catch ( Exception e ) {
-                e.printStackTrace();
-                return 1;
-            }
         }
-
-        return 0;
     }
 
     @Override

--- a/src/test/java/org/utplsql/cli/CliHelpTest.java
+++ b/src/test/java/org/utplsql/cli/CliHelpTest.java
@@ -1,0 +1,11 @@
+package org.utplsql.cli;
+
+import org.junit.jupiter.api.Test;
+
+public class CliHelpTest {
+
+    @Test
+    public void showBasicHelp() {
+        TestHelper.runApp("help");
+    }
+}

--- a/src/test/java/org/utplsql/cli/ReportersCommandIT.java
+++ b/src/test/java/org/utplsql/cli/ReportersCommandIT.java
@@ -1,0 +1,16 @@
+package org.utplsql.cli;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReportersCommandIT {
+
+    @Test
+    public void callReportersWorks() {
+
+        int result = TestHelper.runApp("reporters", TestHelper.getConnectionString());
+
+        assertEquals(0, result);
+    }
+}

--- a/src/test/java/org/utplsql/cli/RunCommandCoverageReporterIT.java
+++ b/src/test/java/org/utplsql/cli/RunCommandCoverageReporterIT.java
@@ -1,16 +1,11 @@
 package org.utplsql.cli;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashSet;
-import java.util.Scanner;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -77,10 +72,9 @@ public class RunCommandCoverageReporterIT extends AbstractFileOutputTest {
 
         Path coveragePath = getTempCoverageFilePath();
 
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(),
+        int result = TestHelper.runApp("run", TestHelper.getConnectionString(),
                 "-f=ut_coverage_html_reporter", "-o=" + coveragePath, "-s", "-exclude=app.award_bonus,app.betwnstr");
 
-        int result = runCmd.run();
 
         String content = new String(Files.readAllBytes(coveragePath));
 
@@ -95,16 +89,13 @@ public class RunCommandCoverageReporterIT extends AbstractFileOutputTest {
         Path coveragePath = getTempCoverageFilePath();
         Path coverageAssetsPath = Paths.get(coveragePath.toString() + "_assets");
 
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(),
+        TestHelper.runApp("run", TestHelper.getConnectionString(),
                 "-f=ut_coverage_html_reporter", "-o=" + coveragePath, "-s");
-
-        runCmd.run();
 
         // Run twice to test overriding of assets
-        runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(),
+        TestHelper.runApp("run", TestHelper.getConnectionString(),
                 "-f=ut_coverage_html_reporter", "-o=" + coveragePath, "-s");
 
-        runCmd.run();
 
         // Check application file exists
         File applicationJs = coverageAssetsPath.resolve(Paths.get("application.js")).toFile();

--- a/src/test/java/org/utplsql/cli/RunCommandIT.java
+++ b/src/test/java/org/utplsql/cli/RunCommandIT.java
@@ -15,16 +15,16 @@ public class RunCommandIT extends AbstractFileOutputTest {
 
     @Test
     public void run_Default() throws Exception {
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(),
+
+        int result = TestHelper.runApp("run",
+                TestHelper.getConnectionString(),
                 "-f=ut_documentation_reporter",
                 "-s",
                 "-c",
                 "--failure-exit-code=2");
 
-        int result = runCmd.run();
-
         // Only expect failure-exit-code to work on several framework versions
-        if (OptionalFeatures.FAIL_ON_ERROR.isAvailableFor(runCmd.getDatabaseVersion()))
+        if (OptionalFeatures.FAIL_ON_ERROR.isAvailableFor(TestHelper.getFrameworkVersion()))
             assertEquals(2, result);
         else
             assertEquals(0, result);
@@ -35,7 +35,8 @@ public class RunCommandIT extends AbstractFileOutputTest {
         String outputFileName = "output_" + System.currentTimeMillis() + ".xml";
         addTempPath(Paths.get(outputFileName));
 
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(),
+        int result = TestHelper.runApp("run",
+                TestHelper.getConnectionString(),
                 "-f=ut_documentation_reporter",
                 "-s",
                 "-f=" + CoreReporters.UT_SONAR_TEST_REPORTER.name(),
@@ -43,10 +44,8 @@ public class RunCommandIT extends AbstractFileOutputTest {
                 "-c",
                 "--failure-exit-code=2");
 
-        int result = runCmd.run();
-
         // Only expect failure-exit-code to work on several framework versions
-        if (OptionalFeatures.FAIL_ON_ERROR.isAvailableFor(runCmd.getDatabaseVersion()))
+        if (OptionalFeatures.FAIL_ON_ERROR.isAvailableFor(TestHelper.getFrameworkVersion()))
             assertEquals(2, result);
         else
             assertEquals(0, result);

--- a/src/test/java/org/utplsql/cli/RunCommandTest.java
+++ b/src/test/java/org/utplsql/cli/RunCommandTest.java
@@ -1,7 +1,6 @@
 package org.utplsql.cli;
 
 import org.junit.jupiter.api.Test;
-import org.utplsql.api.CustomTypes;
 import org.utplsql.api.reporter.CoreReporters;
 
 import java.util.List;
@@ -15,7 +14,7 @@ public class RunCommandTest {
 
     @Test
     public void reporterOptions_Default() {
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString());
+        RunCommand runCmd = TestHelper.createRunCommand(TestHelper.getConnectionString());
 
         List<ReporterOptions> reporterOptionsList = runCmd.getReporterOptionsList();
 
@@ -28,7 +27,7 @@ public class RunCommandTest {
 
     @Test
     public void reporterOptions_OneReporter() {
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(), "-f=ut_documentation_reporter", "-o=output.txt");
+        RunCommand runCmd = TestHelper.createRunCommand(TestHelper.getConnectionString(), "-f=ut_documentation_reporter", "-o=output.txt");
 
         List<ReporterOptions> reporterOptionsList = runCmd.getReporterOptionsList();
 
@@ -41,7 +40,7 @@ public class RunCommandTest {
 
     @Test
     public void reporterOptions_OneReporterForceScreen() {
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(), "-f=ut_documentation_reporter", "-o=output.txt", "-s");
+        RunCommand runCmd = TestHelper.createRunCommand(TestHelper.getConnectionString(), "-f=ut_documentation_reporter", "-o=output.txt", "-s");
 
         List<ReporterOptions> reporterOptionsList = runCmd.getReporterOptionsList();
 
@@ -54,7 +53,7 @@ public class RunCommandTest {
 
     @Test
     public void reporterOptions_OneReporterForceScreenInverse() {
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(), "-f=ut_documentation_reporter", "-s", "-o=output.txt");
+        RunCommand runCmd = TestHelper.createRunCommand(TestHelper.getConnectionString(), "-f=ut_documentation_reporter", "-s", "-o=output.txt");
 
         List<ReporterOptions> reporterOptionsList = runCmd.getReporterOptionsList();
 
@@ -67,7 +66,7 @@ public class RunCommandTest {
 
     @Test
     public void reporterOptions_TwoReporters() {
-        RunCommand runCmd = RunCommandTestHelper.createRunCommand(RunCommandTestHelper.getConnectionString(),
+        RunCommand runCmd = TestHelper.createRunCommand(TestHelper.getConnectionString(),
                 "-f=ut_documentation_reporter",
                 "-f=ut_coverage_html_reporter", "-o=coverage.html", "-s");
 

--- a/src/test/java/org/utplsql/cli/TestHelper.java
+++ b/src/test/java/org/utplsql/cli/TestHelper.java
@@ -1,9 +1,15 @@
 package org.utplsql.cli;
 
 import com.beust.jcommander.JCommander;
+import org.utplsql.api.DBHelper;
 import org.utplsql.api.EnvironmentVariableUtil;
+import org.utplsql.api.Version;
 
-class RunCommandTestHelper {
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+class TestHelper {
     private static String sUrl;
     private static String sUser;
     private static String sPass;
@@ -23,6 +29,17 @@ class RunCommandTestHelper {
                 .build();
 
         return runCmd;
+    }
+
+    static int runApp(String... args) {
+        return Cli.runWithExitCode(args);
+    }
+
+    static Version getFrameworkVersion() throws SQLException {
+        DataSource ds = DataSourceProvider.getDataSource(new ConnectionInfo(TestHelper.getConnectionString()), 1);
+        try (Connection con = ds.getConnection() ) {
+            return DBHelper.getDatabaseFrameworkVersion(con);
+        }
     }
 
     static String getConnectionString() {

--- a/src/test/java/org/utplsql/cli/VersionInfoCommandIT.java
+++ b/src/test/java/org/utplsql/cli/VersionInfoCommandIT.java
@@ -1,8 +1,6 @@
 package org.utplsql.cli;
 
-import com.beust.jcommander.JCommander;
 import org.junit.jupiter.api.Test;
-import org.utplsql.api.EnvironmentVariableUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,32 +9,14 @@ public class VersionInfoCommandIT {
     @Test
     public void infoCommandRunsWithoutConnection() throws Exception {
 
-        VersionInfoCommand infoCmd = new VersionInfoCommand();
-
-        JCommander.newBuilder()
-                .addObject(infoCmd)
-                .args(new String[]{})
-                .build();
-
-        int result = infoCmd.run();
+        int result = TestHelper.runApp("info");
 
         assertEquals(0, result);
     }
     @Test
     public void infoCommandRunsWithConnection() throws Exception {
 
-        String Url  = EnvironmentVariableUtil.getEnvValue("DB_URL", "192.168.99.100:1521:XE");
-        String sUser = EnvironmentVariableUtil.getEnvValue("DB_USER", "app");
-        String sPass = EnvironmentVariableUtil.getEnvValue("DB_PASS", "app");
-
-        VersionInfoCommand infoCmd = new VersionInfoCommand();
-
-        JCommander.newBuilder()
-                .addObject(infoCmd)
-                .args(new String[]{sUser + "/" + sPass + "@" + Url})
-                .build();
-
-        int result = infoCmd.run();
+        int result = TestHelper.runApp("info", TestHelper.getConnectionString());
 
         assertEquals(0, result);
     }

--- a/src/test/java/org/utplsql/cli/VersionInfoCommandIT.java
+++ b/src/test/java/org/utplsql/cli/VersionInfoCommandIT.java
@@ -1,0 +1,43 @@
+package org.utplsql.cli;
+
+import com.beust.jcommander.JCommander;
+import org.junit.jupiter.api.Test;
+import org.utplsql.api.EnvironmentVariableUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VersionInfoCommandIT {
+
+    @Test
+    public void infoCommandRunsWithoutConnection() throws Exception {
+
+        VersionInfoCommand infoCmd = new VersionInfoCommand();
+
+        JCommander.newBuilder()
+                .addObject(infoCmd)
+                .args(new String[]{})
+                .build();
+
+        int result = infoCmd.run();
+
+        assertEquals(0, result);
+    }
+    @Test
+    public void infoCommandRunsWithConnection() throws Exception {
+
+        String Url  = EnvironmentVariableUtil.getEnvValue("DB_URL", "192.168.99.100:1521:XE");
+        String sUser = EnvironmentVariableUtil.getEnvValue("DB_USER", "app");
+        String sPass = EnvironmentVariableUtil.getEnvValue("DB_PASS", "app");
+
+        VersionInfoCommand infoCmd = new VersionInfoCommand();
+
+        JCommander.newBuilder()
+                .addObject(infoCmd)
+                .args(new String[]{sUser + "/" + sPass + "@" + Url})
+                .build();
+
+        int result = infoCmd.run();
+
+        assertEquals(0, result);
+    }
+}

--- a/src/test/java/org/utplsql/cli/VersionInfoCommandIT.java
+++ b/src/test/java/org/utplsql/cli/VersionInfoCommandIT.java
@@ -1,23 +1,61 @@
 package org.utplsql.cli;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.utplsql.cli.util.SystemOutCapturer;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VersionInfoCommandIT {
 
+    private SystemOutCapturer capturer;
+
+    @BeforeEach
+    public void setupCaptureSystemOut() {
+        capturer = new SystemOutCapturer();
+    }
+
+    private int getNonEmptyLines(String content) {
+        return (int) Arrays.stream(content.split("[\n|\r]"))
+                .filter(line -> !line.isEmpty())
+                .count();
+    }
+
+    private void assertNumberOfLines( int expected, String content ) {
+        int numOfLines = getNonEmptyLines(content);
+        assertEquals(expected, numOfLines, String.format("Expected output to have %n lines, but got %n", expected, numOfLines));
+    }
     @Test
     public void infoCommandRunsWithoutConnection() throws Exception {
 
+        capturer.start();
+
         int result = TestHelper.runApp("info");
 
+        String output = capturer.stop();
+
         assertEquals(0, result);
+        assertNumberOfLines(2, output);
     }
     @Test
     public void infoCommandRunsWithConnection() throws Exception {
 
+        capturer.start();
+
         int result = TestHelper.runApp("info", TestHelper.getConnectionString());
 
+        String output = capturer.stop();
+
         assertEquals(0, result);
+        assertNumberOfLines(3, output);
+    }
+
+    @AfterEach
+    public void cleanupCaptureSystemOut() throws IOException {
+        capturer.stop();
     }
 }

--- a/src/test/java/org/utplsql/cli/util/SystemOutCapturer.java
+++ b/src/test/java/org/utplsql/cli/util/SystemOutCapturer.java
@@ -1,0 +1,74 @@
+package org.utplsql.cli.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+
+/** All credit to Manasjyoti Sharma: https://stackoverflow.com/a/30665299
+ */
+public class SystemOutCapturer {
+    private ByteArrayOutputStream baos;
+    private PrintStream previous;
+    private boolean capturing;
+
+    public void start() {
+        if (capturing) {
+            return;
+        }
+
+        capturing = true;
+        previous = System.out;
+        baos = new ByteArrayOutputStream();
+
+        OutputStream outputStreamCombiner =
+                new OutputStreamCombiner(Arrays.asList(previous, baos));
+        PrintStream custom = new PrintStream(outputStreamCombiner);
+
+        System.setOut(custom);
+    }
+
+    public String stop() {
+        if (!capturing) {
+            return "";
+        }
+
+        System.setOut(previous);
+
+        String capturedValue = baos.toString();
+
+        baos = null;
+        previous = null;
+        capturing = false;
+
+        return capturedValue;
+    }
+
+    private static class OutputStreamCombiner extends OutputStream {
+        private List<OutputStream> outputStreams;
+
+        public OutputStreamCombiner(List<OutputStream> outputStreams) {
+            this.outputStreams = outputStreams;
+        }
+
+        public void write(int b) throws IOException {
+            for (OutputStream os : outputStreams) {
+                os.write(b);
+            }
+        }
+
+        public void flush() throws IOException {
+            for (OutputStream os : outputStreams) {
+                os.flush();
+            }
+        }
+
+        public void close() throws IOException {
+            for (OutputStream os : outputStreams) {
+                os.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #77 

Adds a new command "info" with an optional positional parameter to provide a connection.
Will print out information about the version of the used components:

```
cli 3.1.1-SNAPSHOT.local
Java-API 3.1.1-SNAPSHOT.199
utPLSQL 3.1.2.1913
```

Not yet done. Still needs heavy refactoring.

Fixes #31 