### PR TITLE
CoverageHTML Reporter will now reference its assets correctly 

### DIFF
--- a/src/main/java/org/utplsql/cli/reporters/LocalAssetsCoverageHTMLReporter.java
+++ b/src/main/java/org/utplsql/cli/reporters/LocalAssetsCoverageHTMLReporter.java
@@ -6,6 +6,7 @@ import org.utplsql.api.reporter.Reporter;
 import org.utplsql.api.reporter.ReporterFactory;
 import org.utplsql.cli.ReporterOptions;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -27,15 +28,34 @@ public class LocalAssetsCoverageHTMLReporter extends CoverageHTMLReporter implem
     public Reporter init(Connection con, CompatibilityProxy compatibilityProxy, ReporterFactory reporterFactory) throws SQLException {
         super.init(con, compatibilityProxy, reporterFactory);
 
-        if ( options != null && options.outputToFile() )
-            writeReportAssetsTo(Paths.get(getAssetsPath()));
+        if ( hasOutputToFile() ) {
+            writeReportAssetsTo(getPhysicalAssetPath());
+        }
 
         return this;
     }
 
+    private String getNameOfOutputFile() {
+        Path outputPath = Paths.get(options.getOutputFileName());
+        return outputPath.getName(outputPath.getNameCount()-1).toString();
+    }
+
+    private Path getPhysicalAssetPath() {
+        Path outputPath = Paths.get(options.getOutputFileName());
+        if ( outputPath.getNameCount() > 1 )
+            return outputPath.getParent().resolve(getAssetsPath());
+        else
+            return Paths.get(getAssetsPath());
+    }
+
     private void setAssetsPathFromOptions() {
-        if ( options != null && options.outputToFile() )
-            setAssetsPath(options.getOutputFileName()+"_assets/");
+        if ( hasOutputToFile() ) {
+            setAssetsPath(getNameOfOutputFile() + "_assets/");
+        }
+    }
+
+    private boolean hasOutputToFile() {
+        return (options != null && options.outputToFile());
     }
 
     @Override

--- a/src/test/java/org/utplsql/cli/RunCommandCoverageReporterIT.java
+++ b/src/test/java/org/utplsql/cli/RunCommandCoverageReporterIT.java
@@ -109,4 +109,26 @@ public class RunCommandCoverageReporterIT extends AbstractFileOutputTest {
         assertTrue(content.contains("<title>Code coverage</title>"));
     }
 
+    @Test
+    public void coverageReporterWriteAssetsToSubfolder() throws Exception {
+
+        Path origCoveratePath = getTempCoverageFilePath();
+        Path coveragePath = Paths.get(origCoveratePath.toString(), origCoveratePath.toString());
+        Path coverageAssetsPath = Paths.get(coveragePath.toString() + "_assets");
+
+        TestHelper.runApp("run", TestHelper.getConnectionString(),
+                "-f=ut_coverage_html_reporter", "-o=" + coveragePath, "-s");
+
+
+        // Check application file exists
+        File applicationJs = coverageAssetsPath.resolve(Paths.get("application.js")).toFile();
+        assertTrue(applicationJs.exists());
+
+        // Check correct script-part in HTML source exists
+        String content = new String(Files.readAllBytes(coveragePath));
+        assertTrue(content.contains("<script src='" + origCoveratePath.toString() + "_assets" + "/application.js'"));
+
+        // Check correct title exists
+        assertTrue(content.contains("<title>Code coverage</title>"));
+    }
 }


### PR DESCRIPTION
when output is written to a subfolder.
Fixes #94