### PR TITLE
Make easier to use TNS connections

### DIFF
--- a/src/main/java/org/utplsql/cli/DataSourceProvider.java
+++ b/src/main/java/org/utplsql/cli/DataSourceProvider.java
@@ -1,11 +1,14 @@
 package org.utplsql.cli;
 
 import com.zaxxer.hikari.HikariDataSource;
+import org.utplsql.api.EnvironmentVariableUtil;
 import org.utplsql.cli.datasource.TestedDataSourceProvider;
 
 import javax.sql.DataSource;
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.sql.SQLException;
+import java.util.List;
 
 /** Helper class to give you a ready-to-use datasource
  *
@@ -13,12 +16,60 @@ import java.sql.SQLException;
  */
 public class DataSourceProvider {
 
+    private static String oracleHome = null;
+    private static String tnsAdmin = null;
+
     static {
-        String oracleHome = System.getenv("ORACLE_HOME");
-        if (oracleHome != null && System.getProperty("oracle.net.tns_admin") == null) {
-            System.setProperty("oracle.net.tns_admin",
-                    String.join(File.separator, oracleHome, "NETWORK", "ADMIN"));
+        String tnsAdmin = loadOracleHomeAndTnsAdmin();
+        if (tnsAdmin != null && System.getProperty("oracle.net.tns_admin") == null) {
+            System.setProperty("oracle.net.tns_admin", tnsAdmin);
         }
+    }
+
+    private static String loadOracleHomeAndTnsAdmin() {
+        tnsAdmin = EnvironmentVariableUtil.getEnvValue("TNS_ADMIN");
+        if (directoryExists(tnsAdmin)) {
+            return tnsAdmin;
+        }
+
+        oracleHome = EnvironmentVariableUtil.getEnvValue("ORACLE_HOME");
+        if (oracleHome != null) {
+            tnsAdmin = String.join(File.separator, oracleHome, "NETWORK", "ADMIN");
+
+            if (directoryExists(tnsAdmin)) {
+                return tnsAdmin;
+            }
+        }
+
+        try {
+            final int root = WinRegistry.HKEY_LOCAL_MACHINE;
+            final String key = "SOFTWARE\\Oracle";
+
+            List<String> oracleKeys = WinRegistry.readStringSubKeys(root, key);
+            for (String oracleKey : oracleKeys) {
+                String temp = key + "\\" + oracleKey;
+
+                // check for HKEY_LOCAL_MACHINE\SOFTWARE\Oracle\<oracle client>\TNS_ADMIN
+                tnsAdmin = WinRegistry.readString(root, temp, "TNS_ADMIN");
+                if (directoryExists(tnsAdmin)) {
+                    return tnsAdmin;
+                }
+
+                // check for HKEY_LOCAL_MACHINE\SOFTWARE\Oracle\<oracle client>\ORACLE_HOME
+                oracleHome = WinRegistry.readString(root, temp, "ORACLE_HOME");
+                tnsAdmin = String.join(File.separator, oracleHome, "NETWORK", "ADMIN");
+                if (directoryExists(tnsAdmin)) {
+                    return tnsAdmin;
+                }
+            }
+        } catch (ExceptionInInitializerError | IllegalAccessException | InvocationTargetException e) {
+        }
+
+        return null;
+    }
+
+    private static boolean directoryExists(String path) {
+        return path != null && new File(path).exists();
     }
 
     public static DataSource getDataSource(ConnectionInfo info, int maxConnections ) throws SQLException {
@@ -31,6 +82,14 @@ public class DataSourceProvider {
         pds.setAutoCommit(false);
         pds.setMaximumPoolSize(maxConnections);
         return pds;
+    }
+
+    public static String getOracleHome() {
+        return oracleHome;
+    }
+
+    public static String getTnsAdmin() {
+        return tnsAdmin;
     }
 
     private static void requireOjdbc() {

--- a/src/main/java/org/utplsql/cli/RunCommand.java
+++ b/src/main/java/org/utplsql/cli/RunCommand.java
@@ -260,7 +260,8 @@ public class RunCommand implements ICommand {
         formatter.appendLine(CliVersionInfo.getInfo());
         formatter.appendLine(JavaApiVersionInfo.getInfo());
         formatter.appendLine("Java-Version: " + System.getProperty("java.version"));
-        formatter.appendLine("ORACLE_HOME: " + EnvironmentVariableUtil.getEnvValue("ORACLE_HOME"));
+        formatter.appendLine("ORACLE_HOME: " + DataSourceProvider.getOracleHome());
+        formatter.appendLine("TNS_ADMIN: " + DataSourceProvider.getTnsAdmin());
         formatter.appendLine("NLS_LANG: " + EnvironmentVariableUtil.getEnvValue("NLS_LANG"));
         formatter.appendLine("");
         formatter.appendLine("Thanks for testing!");

--- a/src/main/java/org/utplsql/cli/WinRegistry.java
+++ b/src/main/java/org/utplsql/cli/WinRegistry.java
@@ -1,0 +1,384 @@
+package org.utplsql.cli;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.Preferences;
+
+public class WinRegistry {
+    public static final int HKEY_CURRENT_USER = 0x80000001;
+    public static final int HKEY_LOCAL_MACHINE = 0x80000002;
+    public static final int REG_SUCCESS = 0;
+    public static final int REG_NOTFOUND = 2;
+    public static final int REG_ACCESSDENIED = 5;
+
+    private static final int KEY_ALL_ACCESS = 0xf003f;
+    private static final int KEY_READ = 0x20019;
+    private static final Preferences userRoot = Preferences.userRoot();
+    private static final Preferences systemRoot = Preferences.systemRoot();
+    private static final Class<? extends Preferences> userClass = userRoot.getClass();
+    private static final Method regOpenKey;
+    private static final Method regCloseKey;
+    private static final Method regQueryValueEx;
+    private static final Method regEnumValue;
+    private static final Method regQueryInfoKey;
+    private static final Method regEnumKeyEx;
+    private static final Method regCreateKeyEx;
+    private static final Method regSetValueEx;
+    private static final Method regDeleteKey;
+    private static final Method regDeleteValue;
+
+    static {
+        try {
+            regOpenKey = userClass.getDeclaredMethod("WindowsRegOpenKey",
+                    int.class, byte[].class, int.class);
+            regOpenKey.setAccessible(true);
+            regCloseKey = userClass.getDeclaredMethod("WindowsRegCloseKey",
+                    int.class);
+            regCloseKey.setAccessible(true);
+            regQueryValueEx = userClass.getDeclaredMethod("WindowsRegQueryValueEx",
+                    int.class, byte[].class);
+            regQueryValueEx.setAccessible(true);
+            regEnumValue = userClass.getDeclaredMethod("WindowsRegEnumValue",
+                    int.class, int.class, int.class);
+            regEnumValue.setAccessible(true);
+            regQueryInfoKey = userClass.getDeclaredMethod("WindowsRegQueryInfoKey1",
+                    int.class);
+            regQueryInfoKey.setAccessible(true);
+            regEnumKeyEx = userClass.getDeclaredMethod(
+                    "WindowsRegEnumKeyEx", int.class, int.class,
+                    int.class);
+            regEnumKeyEx.setAccessible(true);
+            regCreateKeyEx = userClass.getDeclaredMethod(
+                    "WindowsRegCreateKeyEx", int.class,
+                    byte[].class);
+            regCreateKeyEx.setAccessible(true);
+            regSetValueEx = userClass.getDeclaredMethod(
+                    "WindowsRegSetValueEx", int.class,
+                    byte[].class, byte[].class);
+            regSetValueEx.setAccessible(true);
+            regDeleteValue = userClass.getDeclaredMethod(
+                    "WindowsRegDeleteValue", int.class,
+                    byte[].class);
+            regDeleteValue.setAccessible(true);
+            regDeleteKey = userClass.getDeclaredMethod(
+                    "WindowsRegDeleteKey", int.class,
+                    byte[].class);
+            regDeleteKey.setAccessible(true);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private WinRegistry() {  }
+
+    /**
+     * Read a value from key and value name
+     * @param hkey   HKEY_CURRENT_USER/HKEY_LOCAL_MACHINE
+     * @param key
+     * @param valueName
+     * @return the value
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public static String readString(int hkey, String key, String valueName)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        if (hkey == HKEY_LOCAL_MACHINE) {
+            return readString(systemRoot, hkey, key, valueName);
+        }
+        else if (hkey == HKEY_CURRENT_USER) {
+            return readString(userRoot, hkey, key, valueName);
+        }
+        else {
+            throw new IllegalArgumentException("hkey=" + hkey);
+        }
+    }
+
+    /**
+     * Read value(s) and value name(s) form given key
+     * @param hkey  HKEY_CURRENT_USER/HKEY_LOCAL_MACHINE
+     * @param key
+     * @return the value name(s) plus the value(s)
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public static Map<String, String> readStringValues(int hkey, String key)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        if (hkey == HKEY_LOCAL_MACHINE) {
+            return readStringValues(systemRoot, hkey, key);
+        }
+        else if (hkey == HKEY_CURRENT_USER) {
+            return readStringValues(userRoot, hkey, key);
+        }
+        else {
+            throw new IllegalArgumentException("hkey=" + hkey);
+        }
+    }
+
+    /**
+     * Read the value name(s) from a given key
+     * @param hkey  HKEY_CURRENT_USER/HKEY_LOCAL_MACHINE
+     * @param key
+     * @return the value name(s)
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public static List<String> readStringSubKeys(int hkey, String key)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        if (hkey == HKEY_LOCAL_MACHINE) {
+            return readStringSubKeys(systemRoot, hkey, key);
+        }
+        else if (hkey == HKEY_CURRENT_USER) {
+            return readStringSubKeys(userRoot, hkey, key);
+        }
+        else {
+            throw new IllegalArgumentException("hkey=" + hkey);
+        }
+    }
+
+    /**
+     * Create a key
+     * @param hkey  HKEY_CURRENT_USER/HKEY_LOCAL_MACHINE
+     * @param key
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public static void createKey(int hkey, String key)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        int [] ret;
+        if (hkey == HKEY_LOCAL_MACHINE) {
+            ret = createKey(systemRoot, hkey, key);
+            regCloseKey.invoke(systemRoot, ret[0]);
+        }
+        else if (hkey == HKEY_CURRENT_USER) {
+            ret = createKey(userRoot, hkey, key);
+            regCloseKey.invoke(userRoot, ret[0]);
+        }
+        else {
+            throw new IllegalArgumentException("hkey=" + hkey);
+        }
+        if (ret[1] != REG_SUCCESS) {
+            throw new IllegalArgumentException("rc=" + ret[1] + "  key=" + key);
+        }
+    }
+
+    /**
+     * Write a value in a given key/value name
+     * @param hkey
+     * @param key
+     * @param valueName
+     * @param value
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public static void writeStringValue
+    (int hkey, String key, String valueName, String value)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        if (hkey == HKEY_LOCAL_MACHINE) {
+            writeStringValue(systemRoot, hkey, key, valueName, value);
+        }
+        else if (hkey == HKEY_CURRENT_USER) {
+            writeStringValue(userRoot, hkey, key, valueName, value);
+        }
+        else {
+            throw new IllegalArgumentException("hkey=" + hkey);
+        }
+    }
+
+    /**
+     * Delete a given key
+     * @param hkey
+     * @param key
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public static void deleteKey(int hkey, String key)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        int rc = -1;
+        if (hkey == HKEY_LOCAL_MACHINE) {
+            rc = deleteKey(systemRoot, hkey, key);
+        }
+        else if (hkey == HKEY_CURRENT_USER) {
+            rc = deleteKey(userRoot, hkey, key);
+        }
+        if (rc != REG_SUCCESS) {
+            throw new IllegalArgumentException("rc=" + rc + "  key=" + key);
+        }
+    }
+
+    /**
+     * delete a value from a given key/value name
+     * @param hkey
+     * @param key
+     * @param value
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public static void deleteValue(int hkey, String key, String value)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        int rc = -1;
+        if (hkey == HKEY_LOCAL_MACHINE) {
+            rc = deleteValue(systemRoot, hkey, key, value);
+        }
+        else if (hkey == HKEY_CURRENT_USER) {
+            rc = deleteValue(userRoot, hkey, key, value);
+        }
+        if (rc != REG_SUCCESS) {
+            throw new IllegalArgumentException("rc=" + rc + "  key=" + key + "  value=" + value);
+        }
+    }
+
+    // =====================
+
+    private static int deleteValue
+            (Preferences root, int hkey, String key, String value)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        int[] handles = (int[]) regOpenKey.invoke(root, new Object[] {
+                hkey, toCstr(key), KEY_ALL_ACCESS});
+        if (handles[1] != REG_SUCCESS) {
+            return handles[1];  // can be REG_NOTFOUND, REG_ACCESSDENIED
+        }
+        int rc = (Integer) regDeleteValue.invoke(root,
+                new Object[]{
+                        handles[0], toCstr(value)
+                });
+        regCloseKey.invoke(root, handles[0]);
+        return rc;
+    }
+
+    private static int deleteKey(Preferences root, int hkey, String key)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        int rc = (Integer) regDeleteKey.invoke(root,
+                new Object[]{hkey, toCstr(key)});
+        return rc;  // can REG_NOTFOUND, REG_ACCESSDENIED, REG_SUCCESS
+    }
+
+    private static String readString(Preferences root, int hkey, String key, String value)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        int[] handles = (int[]) regOpenKey.invoke(root, new Object[] {
+                hkey, toCstr(key), KEY_READ});
+        if (handles[1] != REG_SUCCESS) {
+            return null;
+        }
+        byte[] valb = (byte[]) regQueryValueEx.invoke(root, new Object[] {
+                handles[0], toCstr(value) });
+        regCloseKey.invoke(root, handles[0]);
+        return (valb != null ? new String(valb).trim() : null);
+    }
+
+    private static Map<String,String> readStringValues
+            (Preferences root, int hkey, String key)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        HashMap<String, String> results = new HashMap<String,String>();
+        int[] handles = (int[]) regOpenKey.invoke(root, new Object[] {
+                hkey, toCstr(key), KEY_READ});
+        if (handles[1] != REG_SUCCESS) {
+            return null;
+        }
+        int[] info = (int[]) regQueryInfoKey.invoke(root,
+                new Object[] {handles[0]});
+
+        int count = info[0]; // count
+        int maxlen = info[3]; // value length max
+        for(int index=0; index<count; index++)  {
+            byte[] name = (byte[]) regEnumValue.invoke(root, new Object[] {
+                    handles[0], index, maxlen + 1});
+            String value = readString(hkey, key, new String(name));
+            results.put(new String(name).trim(), value);
+        }
+        regCloseKey.invoke(root, handles[0]);
+        return results;
+    }
+
+    private static List<String> readStringSubKeys
+            (Preferences root, int hkey, String key)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        List<String> results = new ArrayList<String>();
+        int[] handles = (int[]) regOpenKey.invoke(root, new Object[] {
+                hkey, toCstr(key), KEY_READ
+        });
+        if (handles[1] != REG_SUCCESS) {
+            return null;
+        }
+        int[] info = (int[]) regQueryInfoKey.invoke(root,
+                new Object[] {handles[0]});
+
+        int count  = info[0]; // Fix: info[2] was being used here with wrong results. Suggested by davenpcj, confirmed by Petrucio
+        int maxlen = info[3]; // value length max
+        for(int index=0; index<count; index++)  {
+            byte[] name = (byte[]) regEnumKeyEx.invoke(root, new Object[] {
+                    handles[0], index, maxlen + 1
+            });
+            results.add(new String(name).trim());
+        }
+        regCloseKey.invoke(root, handles[0]);
+        return results;
+    }
+
+    private static int [] createKey(Preferences root, int hkey, String key)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        return  (int[]) regCreateKeyEx.invoke(root,
+                new Object[] {hkey, toCstr(key) });
+    }
+
+    private static void writeStringValue
+            (Preferences root, int hkey, String key, String valueName, String value)
+            throws IllegalArgumentException, IllegalAccessException,
+            InvocationTargetException
+    {
+        int[] handles = (int[]) regOpenKey.invoke(root, new Object[] {
+                hkey, toCstr(key), KEY_ALL_ACCESS});
+
+        regSetValueEx.invoke(root,
+                handles[0], toCstr(valueName), toCstr(value));
+        regCloseKey.invoke(root, handles[0]);
+    }
+
+    // utility
+    private static byte[] toCstr(String str) {
+        byte[] result = new byte[str.length() + 1];
+
+        for (int i = 0; i < str.length(); i++) {
+            result[i] = (byte) str.charAt(i);
+        }
+        result[str.length()] = 0;
+        return result;
+    }
+}


### PR DESCRIPTION
Currently if the Java property oracle.net.tns_admin isn't set, the cli will define it as "ORACLE_HOME/network/admin". This is an attempt to make easier to use TNS connections as discussed in #112. I separated my changes in two commits for easier discussion.

The first commit is a very straightforward change: if there's a TNS_ADMIN environment variable set and it's a valid path, use it to set oracle.net.tns_admin.

The second commit adds a bit more complexity. The idea is:
- read all subkeys of `HKEY_LOCAL_MACHINE\SOFTWARE\Oracle`
- check for `HKEY_LOCAL_MACHINE\SOFTWARE\Oracle\<subkey>\TNS_ADMIN` and use it if it's valid
- check for `HKEY_LOCAL_MACHINE\SOFTWARE\Oracle\<subkey>\ORACLE_HOME` and if "ORACLE_HOME/network/admin" is valid, use it

The code queries the 64-bit view of the Windows registry (`HKEY_LOCAL_MACHINE\SOFTWARE\Oracle`) and the 32-bit view (`HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Oracle`).

But this second commit also adds a dependency of [JNA](https://github.com/java-native-access/jna), therefore two new .jar would need to be distributed with utPLSQL-cli: jna-5.1.0.jar (1.41 MB) and jna-platform-5.1.0.jar (2.4 MB). The JNA library can be distributed under the Apache License too, so it's safe to use.

(It looks like there are [a hackish way](https://stackoverflow.com/a/6163701) to access the Windows registry without any extra dependency, but... well... it's too hackish IMHO)