### PR TITLE
bugfix/Handling Timeout and Oracle CreateStatement stuck scenario

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,18 @@
           <artifactId>logback-classic</artifactId>
           <version>1.2.3</version>
       </dependency>
+      <dependency>
+          <groupId>com.oracle.jdbc</groupId>
+          <artifactId>ojdbc8</artifactId>
+          <version>12.2.0.1</version>
+          <scope>compile</scope>
+      </dependency>
+      <dependency>
+          <groupId>com.oracle.jdbc</groupId>
+          <artifactId>orai18n</artifactId>
+          <version>12.2.0.1</version>
+          <scope>compile</scope>
+      </dependency>
 
       <!-- Test -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,14 @@
                   <groupId>com.oracle.jdbc</groupId>
                   <artifactId>ucp</artifactId>
               </exclusion>
+              <exclusion>
+                  <groupId>com.oracle.jdbc</groupId>
+                  <artifactId>ojdbc8</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>com.oracle.jdbc</groupId>
+                  <artifactId>orai18n</artifactId>
+              </exclusion>
           </exclusions>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,25 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>maven.oracle.com</id>
+      <releases>
+          <enabled>true</enabled>
+      </releases>
+      <snapshots>
+          <enabled>false</enabled>
+      </snapshots>
+      <url>https://maven.oracle.com</url>
+      <layout>default</layout>
+    </repository>
   </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>maven.oracle.com</id>
+            <url>https://maven.oracle.com</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <profiles>
         <profile>

--- a/src/main/java/org/utplsql/cli/RunTestRunnerTask.java
+++ b/src/main/java/org/utplsql/cli/RunTestRunnerTask.java
@@ -1,0 +1,65 @@
+package org.utplsql.cli;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.utplsql.api.TestRunner;
+import org.utplsql.api.exception.OracleCreateStatmenetStuckException;
+import org.utplsql.api.exception.SomeTestsFailedException;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+
+/** Runs the utPLSQL Test-Runner
+ *
+ * Takes care of its connection.
+ * In case of an OracleCreateStatementStuckException it will abort the connection, otherwise close it.
+ *
+ * @author pesse
+ */
+public class RunTestRunnerTask implements Callable<Boolean> {
+
+    private static final Logger logger = LoggerFactory.getLogger(RunTestRunnerTask.class);
+    private DataSource dataSource;
+    private TestRunner testRunner;
+
+    RunTestRunnerTask(DataSource dataSource, TestRunner testRunner) {
+        this.dataSource = dataSource;
+        this.testRunner = testRunner;
+    }
+
+    @Override
+    public Boolean call() throws Exception {
+        Connection conn = null;
+        try  {
+            conn = dataSource.getConnection();
+            logger.info("Running tests now.");
+            logger.info("--------------------------------------");
+            testRunner.run(conn);
+        } catch (SomeTestsFailedException e) {
+            throw e;
+        } catch (OracleCreateStatmenetStuckException e ) {
+            try {
+                conn.abort(Executors.newSingleThreadExecutor());
+                conn = null;
+            } catch (SQLException e1) {
+                logger.error(e1.getMessage(), e1);
+            }
+            throw e;
+        } catch (SQLException e) {
+            System.out.println(e.getMessage());
+            throw e;
+        } finally {
+            if ( conn != null ) {
+                try {
+                    conn.close();
+                } catch (SQLException e) {
+                    logger.error(e.getMessage(), e);
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/utplsql/cli/TestRunnerTask.java
+++ b/src/main/java/org/utplsql/cli/TestRunnerTask.java
@@ -1,0 +1,24 @@
+package org.utplsql.cli;
+
+import org.utplsql.api.TestRunner;
+
+import java.sql.Connection;
+import java.util.concurrent.ExecutorService;
+
+class TestRunnerTask implements Runnable {
+
+    private Connection con;
+    private TestRunner testRunner;
+    private ExecutorService executorService;
+
+    TestRunnerTask(Connection con, TestRunner testRunner, ExecutorService executorService ) {
+        this.con = con;
+        this.testRunner = testRunner;
+        this.executorService = executorService;
+    }
+
+    @Override
+    public void run() {
+
+    }
+}

--- a/src/main/java/org/utplsql/cli/exception/ReporterTimeoutException.java
+++ b/src/main/java/org/utplsql/cli/exception/ReporterTimeoutException.java
@@ -1,0 +1,15 @@
+package org.utplsql.cli.exception;
+
+public class ReporterTimeoutException extends Exception {
+
+    private final int timeOutInMinutes;
+
+    public ReporterTimeoutException( int timeoutInMinutes ) {
+        super("Timeout while waiting for reporters to finish for " + timeoutInMinutes + " minutes");
+        this.timeOutInMinutes = timeoutInMinutes;
+    }
+
+    public int getTimeOutInMinutes() {
+        return timeOutInMinutes;
+    }
+}

--- a/src/test/java/org/utplsql/cli/RunCommandIssue20Test.java
+++ b/src/test/java/org/utplsql/cli/RunCommandIssue20Test.java
@@ -1,0 +1,46 @@
+package org.utplsql.cli;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.utplsql.api.reporter.CoreReporters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for run command.
+ */
+class RunCommandIssue20Test {
+
+    private static final Logger logger = LoggerFactory.getLogger(RunCommandIssue20Test.class);
+
+    @Test
+    void runLoop() {
+        RunCommand runCmd = TestHelper.createRunCommand(
+                TestHelper.getConnectionString(),
+                "-p=TEST_BETWNSTR.normal_case",
+                "-f=ut_documentation_reporter");
+        List<ReporterOptions> reporterOptionsList = runCmd.getReporterOptionsList();
+        ReporterOptions reporterOptions1 = reporterOptionsList.get(0);
+        assertEquals(CoreReporters.UT_DOCUMENTATION_REPORTER.name(), reporterOptions1.getReporterName());
+        assertTrue(reporterOptions1.outputToScreen());
+        // Loop in same JVM, uses a lot of new connections without closing existing ones, this might lead to 
+        //   "Could not establish connection to database. Reason: IO Error: Got minus one from a read call"
+        // before hitting the hanger at oracle.jdbc.driver.OracleStruct.getOracleAttributes(OracleStruct.java:347)
+        // You may increase processes and implicitly sessions by "alter system set processes=1024 scope=spfile;"
+        for (int i=0; i <= 120; i++) {
+            logger.info("=======================");
+            logger.info("Loop number " + i);
+            logger.info("=======================");
+            int result = runCmd.run();
+            if (result != 0) {
+                logger.error("Got an error during run. Return Code was " + result + "." );
+                break;
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/utplsql/cli/RunCommandIssue20Test.java
+++ b/src/test/java/org/utplsql/cli/RunCommandIssue20Test.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test for run command.
+ *
+ * @author philipp salivsberg
  */
 class RunCommandIssue20Test {
 


### PR DESCRIPTION
- On timeout, an exception is reported and Return code is 1.
- When the java-api reports an OracleCreateStatementStuck-Scenario, the current Run is aborted completely and a brand new Run is started automatically (max 5 times)
- POM now contains the necessary oracle drivers (previously inherited by java-api)