### PR TITLE
Feature/connect as sysdba

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ UT_XUNIT_REPORTER:
     Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
 ```
 
+## Using utPLSQL-cli as sysdba
+
+Since 3.1.3 it is possible to run utPLSQL-cli as sysdba by running
+
+```
+utplsql run "sys as sysdba"/pw@connectstring
+```
+
+It is, however, __not recommended__ to run utPLSQL with sysdba privileges.
+
 ## Enabling Color Outputs on Windows
 
 To enable color outputs on Windows cmd you need to install an open-source utility called [ANSICON](http://adoxa.altervista.org/ansicon/).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ To connect using TNS, you need to have the ORACLE_HOME environment variable set.
 The file tnsnames.ora must exist in path %ORACLE_HOME%/network/admin
 The file tnsnames.ora must contain valid TNS entries. 
 
+In case you use a username containing `/` or a password containing `@` you should encapsulate it with double quotes `"`:
+```
+utplsql run "my/Username"/"myP@ssword"@connectstring
+```
+
 ### run
 `utplsql run <ConnectionURL> [<options>]`
                                                                  

--- a/src/main/java/org/utplsql/cli/ConnectionConfig.java
+++ b/src/main/java/org/utplsql/cli/ConnectionConfig.java
@@ -10,14 +10,24 @@ public class ConnectionConfig {
     private final String connect;
 
     public ConnectionConfig( String connectString ) {
-        Matcher m = Pattern.compile("^([^/]+)/([^@]+)@(.*)$").matcher(connectString);
+        Matcher m = Pattern.compile("^(\".+\"|[^/]+)/(\".+\"|[^@]+)@(.*)$").matcher(connectString);
         if ( m.find() ) {
-            user = m.group(1);
-            password = m.group(2);
+            user = stripEnclosingQuotes(m.group(1));
+            password = stripEnclosingQuotes(m.group(2));
             connect = m.group(3);
         }
         else
             throw new IllegalArgumentException("Not a valid connectString: '" + connectString + "'");
+    }
+
+    private String stripEnclosingQuotes( String value ) {
+        if ( value.length() > 1
+                && value.startsWith("\"")
+                && value.endsWith("\"")) {
+            return value.substring(1, value.length()-1);
+        } else {
+            return value;
+        }
     }
 
     public String getConnect() {

--- a/src/main/java/org/utplsql/cli/ConnectionConfig.java
+++ b/src/main/java/org/utplsql/cli/ConnectionConfig.java
@@ -45,4 +45,10 @@ public class ConnectionConfig {
     public String getConnectString() {
         return user + "/" + password + "@" + connect;
     }
+
+    public boolean isSysDba() {
+        return user != null &&
+                (user.toLowerCase().endsWith(" as sysdba")
+                || user.toLowerCase().endsWith(" as sysoper"));
+    }
 }

--- a/src/main/java/org/utplsql/cli/DataSourceProvider.java
+++ b/src/main/java/org/utplsql/cli/DataSourceProvider.java
@@ -26,6 +26,7 @@ public class DataSourceProvider {
         requireOjdbc();
 
         ConnectionConfig config = new ConnectionConfig(info.getConnectionString());
+        warnIfSysDba(config);
 
         HikariDataSource pds = new TestedDataSourceProvider(config).getDataSource();
         pds.setAutoCommit(false);
@@ -41,6 +42,12 @@ public class DataSourceProvider {
             System.out.println("Download from http://www.oracle.com/technetwork/database/features/jdbc/jdbc-ucp-122-3110062.html");
 
             throw new RuntimeException("Can't run utPLSQL-cli without Oracle JDBC driver");
+        }
+    }
+
+    private static void warnIfSysDba(ConnectionConfig config) {
+        if ( config.isSysDba() ) {
+            System.out.println("WARNING: You are connecting to the database as SYSDBA or SYSOPER, which is NOT RECOMMENDED and can put your database at risk!");
         }
     }
 }

--- a/src/main/java/org/utplsql/cli/RunCommand.java
+++ b/src/main/java/org/utplsql/cli/RunCommand.java
@@ -124,7 +124,7 @@ public class RunCommand implements ICommand {
     private ReporterFactory reporterFactory;
     private ReporterManager reporterManager;
 
-    private ConnectionInfo getConnectionInfo() {
+    ConnectionInfo getConnectionInfo() {
         return connectionInfoList.get(0);
     }
 

--- a/src/test/java/org/utplsql/cli/ConnectionConfigTest.java
+++ b/src/test/java/org/utplsql/cli/ConnectionConfigTest.java
@@ -2,7 +2,7 @@ package org.utplsql.cli;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConnectionConfigTest {
 
@@ -13,6 +13,7 @@ public class ConnectionConfigTest {
         assertEquals("test", info.getUser());
         assertEquals("pw", info.getPassword());
         assertEquals("my.local.host/service", info.getConnect());
+        assertFalse(info.isSysDba());
     }
 
     @Test
@@ -22,6 +23,16 @@ public class ConnectionConfigTest {
         assertEquals("sys as sysdba", info.getUser());
         assertEquals("pw", info.getPassword());
         assertEquals("my.local.host/service", info.getConnect());
+        assertTrue(info.isSysDba());
+    }
+    @Test
+    void parseSysOper() {
+        ConnectionConfig info = new ConnectionConfig("myOperUser as sysoper/passw0rd@my.local.host/service");
+
+        assertEquals("myOperUser as sysoper", info.getUser());
+        assertEquals("passw0rd", info.getPassword());
+        assertEquals("my.local.host/service", info.getConnect());
+        assertTrue(info.isSysDba());
     }
 
     @Test
@@ -31,6 +42,7 @@ public class ConnectionConfigTest {
         assertEquals("test", info.getUser());
         assertEquals("p@ssw0rd=", info.getPassword());
         assertEquals("my.local.host/service", info.getConnect());
+        assertFalse(info.isSysDba());
     }
 
     @Test
@@ -40,5 +52,6 @@ public class ConnectionConfigTest {
         assertEquals("User/Mine@=", info.getUser());
         assertEquals("pw", info.getPassword());
         assertEquals("my.local.host/service", info.getConnect());
+        assertFalse(info.isSysDba());
     }
 }

--- a/src/test/java/org/utplsql/cli/ConnectionConfigTest.java
+++ b/src/test/java/org/utplsql/cli/ConnectionConfigTest.java
@@ -1,0 +1,44 @@
+package org.utplsql.cli;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConnectionConfigTest {
+
+    @Test
+    void parse() {
+        ConnectionConfig info = new ConnectionConfig("test/pw@my.local.host/service");
+
+        assertEquals("test", info.getUser());
+        assertEquals("pw", info.getPassword());
+        assertEquals("my.local.host/service", info.getConnect());
+    }
+
+    @Test
+    void parseSysDba() {
+        ConnectionConfig info = new ConnectionConfig("sys as sysdba/pw@my.local.host/service");
+
+        assertEquals("sys as sysdba", info.getUser());
+        assertEquals("pw", info.getPassword());
+        assertEquals("my.local.host/service", info.getConnect());
+    }
+
+    @Test
+    void parseSpecialCharsPW() {
+        ConnectionConfig info = new ConnectionConfig("test/\"p@ssw0rd=\"@my.local.host/service");
+
+        assertEquals("test", info.getUser());
+        assertEquals("p@ssw0rd=", info.getPassword());
+        assertEquals("my.local.host/service", info.getConnect());
+    }
+
+    @Test
+    void parseSpecialCharsUser() {
+        ConnectionConfig info = new ConnectionConfig("\"User/Mine@=\"/pw@my.local.host/service");
+
+        assertEquals("User/Mine@=", info.getUser());
+        assertEquals("pw", info.getPassword());
+        assertEquals("my.local.host/service", info.getConnect());
+    }
+}

--- a/src/test/java/org/utplsql/cli/DataSourceProviderIT.java
+++ b/src/test/java/org/utplsql/cli/DataSourceProviderIT.java
@@ -20,6 +20,14 @@ class DataSourceProviderIT {
         assertNotNull(dataSource);
     }
 
+    //@Test
+    void connectAsSysdba() throws SQLException {
+        ConnectionConfig config = new ConnectionConfig("sys as sysdba/oracle@localhost:1522/ORCLPDB1");
+        DataSource dataSource = new TestedDataSourceProvider(config).getDataSource();
+
+        assertNotNull(dataSource);
+    }
+
     @Test
     void initNlsLang() throws SQLException {
         System.setProperty("NLS_LANG", "BRAZILIAN PORTUGUESE_BRAZIL.WE8ISO8859P1");

--- a/src/test/java/org/utplsql/cli/RunCommandIT.java
+++ b/src/test/java/org/utplsql/cli/RunCommandIT.java
@@ -5,6 +5,7 @@ import org.utplsql.api.compatibility.OptionalFeatures;
 import org.utplsql.api.reporter.CoreReporters;
 
 import java.nio.file.Paths;
+import java.sql.SQLException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -12,6 +13,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * System tests for run command.
  */
 class RunCommandIT extends AbstractFileOutputTest {
+
+    private void assertValidReturnCode(int returnCode) throws SQLException {
+        // Only expect failure-exit-code to work on several framework versions
+        if (OptionalFeatures.FAIL_ON_ERROR.isAvailableFor(TestHelper.getFrameworkVersion()))
+            assertEquals(2, returnCode);
+        else
+            assertEquals(0, returnCode);
+    }
 
     @Test
     void run_Default() throws Exception {
@@ -23,11 +32,7 @@ class RunCommandIT extends AbstractFileOutputTest {
                 "-c",
                 "--failure-exit-code=2");
 
-        // Only expect failure-exit-code to work on several framework versions
-        if (OptionalFeatures.FAIL_ON_ERROR.isAvailableFor(TestHelper.getFrameworkVersion()))
-            assertEquals(2, result);
-        else
-            assertEquals(0, result);
+        assertValidReturnCode(result);
     }
 
     @Test
@@ -35,9 +40,10 @@ class RunCommandIT extends AbstractFileOutputTest {
 
         int result = TestHelper.runApp("run",
                 TestHelper.getConnectionString(),
-                "--debug");
+                "--debug",
+                "--failure-exit-code=2");
 
-        assertEquals(1, result);
+        assertValidReturnCode(result);
     }
 
     @Test
@@ -55,11 +61,7 @@ class RunCommandIT extends AbstractFileOutputTest {
                 "-c",
                 "--failure-exit-code=2");
 
-        // Only expect failure-exit-code to work on several framework versions
-        if (OptionalFeatures.FAIL_ON_ERROR.isAvailableFor(TestHelper.getFrameworkVersion()))
-            assertEquals(2, result);
-        else
-            assertEquals(0, result);
+        assertValidReturnCode(result);
     }
 
 

--- a/src/test/java/org/utplsql/cli/RunCommandTest.java
+++ b/src/test/java/org/utplsql/cli/RunCommandTest.java
@@ -85,4 +85,11 @@ class RunCommandTest {
         assertTrue(reporterOptions2.outputToScreen());
     }
 
+    @Test
+    void connectionString_asSysdba() {
+        RunCommand runCmd = TestHelper.createRunCommand("sys as sysdba/mypass@connectstring/service");
+
+        assertEquals("sys as sysdba/mypass@connectstring/service",
+                runCmd.getConnectionInfo().getConnectionString());
+    }
 }

--- a/src/test/java/org/utplsql/cli/TestHelper.java
+++ b/src/test/java/org/utplsql/cli/TestHelper.java
@@ -45,4 +45,16 @@ class TestHelper {
     static String getConnectionString() {
         return sUser + "/" + sPass + "@" + sUrl;
     }
+
+    static String getUser() {
+        return sUser;
+    }
+
+    static String getPass() {
+        return sPass;
+    }
+
+    static String getUrl() {
+        return sUrl;
+    }
 }


### PR DESCRIPTION
- Adds some Unit-Tests around parsing connectString
- Allows user-part of the connectstring to contain "/" if enclosed in double quotes (e.g. `"my/user"/pass@connectstring`)
- Allows password-part of the connectstring to contain "@" if enclosed in double quotes (e.g. `app/"myP@ssw/rd="@connecstring`)
- Allows to connect as sysdba via adding the "as" part to the username (e.g. `"sys as sysdba"/pass@connectstring`) (Fixes #115)