### PR TITLE
Bugfix/dbms output enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,12 +219,18 @@ UT_COVERALLS_REPORTER:
     Designed for [Coveralls](https://coveralls.io/).
     JSON format conforms with specification: https://docs.coveralls.io/api-introduction
 
+UT_DEBUG_REPORTER:
+    No description available
+
 UT_DOCUMENTATION_REPORTER:
     A textual pretty-print of unit test results (usually use for console output)
     Provides additional properties lvl and failed
 
 UT_JUNIT_REPORTER:
     Provides outcomes in a format conforming with JUnit 4 and above as defined in: https://gist.github.com/kuzuha/232902acab1344d6b578
+
+UT_REALTIME_REPORTER:
+    Provides test results in a XML format, for clients such as SQL Developer interested in showing progressing details.
 
 UT_SONAR_TEST_REPORTER:
     Generates a JSON report providing detailed information on test execution.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ utplsql run "my/Username"/"myP@ssword"@connectstring
 #### Options
 ```                       
 -p=suite_path(s)    - A suite path or a comma separated list of suite paths for unit test to be executed.     
-                      The path(s) can be in one of the following formats:
+(--path)              The path(s) can be in one of the following formats:
                           schema[.package[.procedure]]
                           schema:suite[.suite[.suite][...]][.procedure]
                       Both formats can be mixed in the list.
@@ -94,7 +94,7 @@ utplsql run "my/Username"/"myP@ssword"@connectstring
                       If -p is omitted, the current schema is used.
                       
 -f=format           - A reporter to be used for reporting.
-                      If no -f option is provided, the default ut_documentation_reporter is used.
+(--format)            If no -f option is provided, the default ut_documentation_reporter is used.
                       See reporters command for possible values
   -o=output         - Defines file name to save the output from the specified reporter.
                       If defined, the output is not displayed on screen by default. This can be changed with the -s parameter.
@@ -119,12 +119,14 @@ utplsql run "my/Username"/"myP@ssword"@connectstring
   -name_subexpression=subexpression_number
     
 -c                  - If specified, enables printing of test results in colors as defined by ANSICONSOLE standards. 
-                      Works only on reporeters that support colors (ut_documentation_reporter).
+(--color)             Works only on reporeters that support colors (ut_documentation_reporter).
                       
---failure-exit-code - Override the exit code on failure, defaults to 1. You can set it to 0 to always exit with a success status.
+-fcode=code         - Override the exit code on failure, defaults to 1. You can set it to 0 to always exit with a success status.
+(--failure-exit-code)
 
 -scc                - If specified, skips the compatibility-check with the version of the database framework.
-                      If you skip compatibility-check, CLI will expect the most actual framework version
+(--skip-              If you skip compatibility-check, CLI will expect the most actual framework version
+ compatibility-check) 
                       
 -include=pckg_list  - Comma-separated object list to include in the coverage report.
                       Format: [schema.]package[,[schema.]package ...].
@@ -135,13 +137,16 @@ utplsql run "my/Username"/"myP@ssword"@connectstring
                       See coverage reporting options in framework documentation.
                       
 -q                  - Does not output the informational messages normally printed to console.
-                      Default: false
+(--quiet)             Default: false
                       
 -d                  - Outputs a load of debug information to console
-                      Default: false
+(--debug)             Default: false
 
--t                  - Sets the timeout in minutes after which the cli will abort. 
-                      Default 60
+-t=timeInMinutes   - Sets the timeout in minutes after which the cli will abort. 
+(--timeout)          Default 60
+                      
+-dbout              - Enables DBMS_OUTPUT in the TestRunner-Session
+(--dbms_output)       Default: false
 ```
 
 Parameters -f, -o, -s are correlated. That is parameters -o and -s are controlling outputs for reporter specified by the preceding -f parameter.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.utplsql</groupId>
   <artifactId>cli</artifactId>
-  <version>3.1.6</version>
+  <version>3.1.7-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cli</name>
@@ -22,7 +22,7 @@
       <dependency>
           <groupId>org.utplsql</groupId>
           <artifactId>java-api</artifactId>
-          <version>3.1.6</version>
+          <version>3.1.7-SNAPSHOT</version>
           <scope>compile</scope>
           <exclusions>
               <exclusion>

--- a/src/main/java/org/utplsql/cli/RunTestRunnerTask.java
+++ b/src/main/java/org/utplsql/cli/RunTestRunnerTask.java
@@ -2,6 +2,7 @@ package org.utplsql.cli;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.utplsql.api.DBHelper;
 import org.utplsql.api.TestRunner;
 import org.utplsql.api.exception.OracleCreateStatmenetStuckException;
 import org.utplsql.api.exception.SomeTestsFailedException;
@@ -24,10 +25,12 @@ public class RunTestRunnerTask implements Callable<Boolean> {
     private static final Logger logger = LoggerFactory.getLogger(RunTestRunnerTask.class);
     private DataSource dataSource;
     private TestRunner testRunner;
+    private boolean enableDmbsOutput;
 
-    RunTestRunnerTask(DataSource dataSource, TestRunner testRunner) {
+    RunTestRunnerTask(DataSource dataSource, TestRunner testRunner, boolean enableDmbsOutput) {
         this.dataSource = dataSource;
         this.testRunner = testRunner;
+        this.enableDmbsOutput = enableDmbsOutput;
     }
 
     @Override
@@ -35,6 +38,7 @@ public class RunTestRunnerTask implements Callable<Boolean> {
         Connection conn = null;
         try  {
             conn = dataSource.getConnection();
+            if ( enableDmbsOutput ) DBHelper.enableDBMSOutput(conn);
             logger.info("Running tests now.");
             logger.info("--------------------------------------");
             testRunner.run(conn);
@@ -54,6 +58,7 @@ public class RunTestRunnerTask implements Callable<Boolean> {
         } finally {
             if ( conn != null ) {
                 try {
+                    if ( enableDmbsOutput ) DBHelper.disableDBMSOutput(conn);
                     conn.close();
                 } catch (SQLException e) {
                     logger.error(e.getMessage(), e);

--- a/src/test/java/org/utplsql/cli/RunCommandIT.java
+++ b/src/test/java/org/utplsql/cli/RunCommandIT.java
@@ -65,4 +65,14 @@ class RunCommandIT extends AbstractFileOutputTest {
     }
 
 
+    @Test
+    void run_withDbmsOutputEnabled() throws Exception {
+
+        int result = TestHelper.runApp("run",
+                TestHelper.getConnectionString(),
+                "-dbout",
+                "--failure-exit-code=2");
+
+        assertValidReturnCode(result);
+    }
 }


### PR DESCRIPTION
Include java-api fix for #136: We can now distinct between real utPLSQL-version and assumed version
New parameter `-dbout, --dbms_output` (Fixes #137)