### PR TITLE
Use new public jdbc driver available one maven central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provides an easy way of invoking utPLSQL from command-line. Main features:
 * Ability to run tests with multiple reporters simultaneously.
 * Ability to save output from every individual reporter to a separate output file.
 * Allows execution of selected suites, subset of suite.
-* Maps project and test files to database objects for reporting purposes. (Comming Soon)
+* Maps project and test files to database objects for reporting purposes. (Coming Soon)
 
 ## Downloading
 
@@ -23,10 +23,6 @@ You can also download all development versions from [Bintray](https://bintray.co
 ## Requirements
 * [Java SE Runtime Environment 8](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html)
 * When using reporters for Sonar or Coveralls client needs to be invoked from project's root directory.
-* Due to Oracle license we can't ship the necessary oracle libraries directly with utPLSQL-cli. <b>Please download the libraries directly from oracle website and put the jars into the "lib" folder of your utPLSQL-cli installation</b>
-  * Oracle `ojdbc8` driver
-  * It is highly recommended that you also use the `orai18n` library, especially if you use a charset different than UTF-16 or are on Oracle 11g.
-  * All of the above can be downloaded from [Oracle download site](http://www.oracle.com/technetwork/database/features/jdbc/jdbc-ucp-122-3110062.html)
 
 ## Compatibility
 The latest CLI is always compatible with all database frameworks of the same major version.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <junit.jupiter.version>5.4.0</junit.jupiter.version>
+        <junit.jupiter.version>5.5.2</junit.jupiter.version>
+        <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version>
         <travisBuildNumber>local</travisBuildNumber>
     </properties>
 
@@ -55,21 +56,21 @@
           <version>4.0.0-beta-1b</version>
       </dependency>
       <dependency>
-          <groupId>com.oracle.jdbc</groupId>
+          <groupId>com.oracle.ojdbc</groupId>
           <artifactId>ojdbc8</artifactId>
-          <version>12.2.0.1</version>
+          <version>${oracle.jdbc.version}</version>
           <scope>compile</scope>
           <exclusions>
               <exclusion>
-                  <groupId>com.oracle.jdbc</groupId>
+                  <groupId>com.oracle.ojdbc</groupId>
                   <artifactId>ucp</artifactId>
               </exclusion>
           </exclusions>
       </dependency>
       <dependency>
-          <groupId>com.oracle.jdbc</groupId>
+          <groupId>com.oracle.ojdbc</groupId>
           <artifactId>orai18n</artifactId>
-          <version>12.2.0.1</version>
+          <version>${oracle.jdbc.version}</version>
           <scope>compile</scope>
       </dependency>
 
@@ -164,25 +165,7 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>maven.oracle.com</id>
-      <releases>
-          <enabled>true</enabled>
-      </releases>
-      <snapshots>
-          <enabled>false</enabled>
-      </snapshots>
-      <url>https://maven.oracle.com</url>
-      <layout>default</layout>
-    </repository>
   </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>maven.oracle.com</id>
-            <url>https://maven.oracle.com</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <profiles>
         <profile>


### PR DESCRIPTION
Oracle published new driver (19.3.0.0) on maven central so no integration with oracle maven is needed anymore. The driver is still compatible with all versions of DB from 11.2 to 19c.