### PR TITLE
Bugfix/Locale-Info and Nullpointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ ALTER SESSION SET NLS_LANGUAGE='AMERICAN';
 ALTER SESSION SET NLS_TERRITORY='AMERICA';
 ```
 
+## Charset
+
+Java will use the default charset of your system for any string output.  
+You can change this by passing the `-Dfile.encoding` property to the JVM when running a java-application.  
+To avoid changing the utPLSQL-cli shell- or batchscript, you can define `-Dfile.encoding` in the environment variable `JAVA_TOOL_OPTIONS`. 
+This environment variable will be picked up and interpreted by the JVM:
+
+```
+export JAVA_TOOL_OPTIONS='-Dfile.encoding=utf8'
+utplsql run user/pw@connecstring
+
+> Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
+``` 
+
+Make sure that the defined charset matches with the codepage your console is using.
+
 ## Usage
 Currently, utPLSQL-cli supports the following sub-commands:
 - run

--- a/pom.xml
+++ b/pom.xml
@@ -27,15 +27,15 @@
           <scope>compile</scope>
           <exclusions>
               <exclusion>
-                  <groupId>com.oracle.jdbc</groupId>
+                  <groupId>com.oracle.ojdbc</groupId>
                   <artifactId>ucp</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>com.oracle.jdbc</groupId>
+                  <groupId>com.oracle.ojdbc</groupId>
                   <artifactId>ojdbc8</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>com.oracle.jdbc</groupId>
+                  <groupId>com.oracle.ojdbc</groupId>
                   <artifactId>orai18n</artifactId>
               </exclusion>
           </exclusions>
@@ -67,7 +67,7 @@
               </exclusion>
           </exclusions>
       </dependency>
-      <dependency>
+     <dependency>
           <groupId>com.oracle.ojdbc</groupId>
           <artifactId>orai18n</artifactId>
           <version>${oracle.jdbc.version}</version>

--- a/src/main/java/org/utplsql/cli/Cli.java
+++ b/src/main/java/org/utplsql/cli/Cli.java
@@ -17,9 +17,6 @@ public class Cli {
 
     static int runPicocliWithExitCode(String[] args) {
 
-        LoggerConfiguration.configure(LoggerConfiguration.ConfigLevel.NONE);
-        LocaleInitializer.initLocale();
-
         CommandLine commandLine = new CommandLine(UtplsqlPicocliCommand.class);
         commandLine.setTrimQuotes(true);
 

--- a/src/main/java/org/utplsql/cli/LocaleInitializer.java
+++ b/src/main/java/org/utplsql/cli/LocaleInitializer.java
@@ -1,5 +1,7 @@
 package org.utplsql.cli;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.utplsql.api.EnvironmentVariableUtil;
 
 import java.util.Locale;
@@ -18,6 +20,8 @@ import java.util.regex.Pattern;
  */
 class LocaleInitializer {
 
+    private static final Logger logger = LoggerFactory.getLogger(RunAction.class);
+
     private static final Pattern REGEX_LOCALE = Pattern.compile("^([a-zA-Z]+)[_-]([a-zA-Z]+)"); // We only need the very first part and are pretty forgiving in parsing
 
     /**
@@ -27,7 +31,10 @@ class LocaleInitializer {
 
         boolean localeChanged = setDefaultLocale(EnvironmentVariableUtil.getEnvValue("LC_ALL"));
         if (!localeChanged) {
-            setDefaultLocale(EnvironmentVariableUtil.getEnvValue("LANG"));
+            localeChanged = setDefaultLocale(EnvironmentVariableUtil.getEnvValue("LANG"));
+        }
+        if ( !localeChanged ) {
+            logger.debug("Java Locale not changed from LC_ALL or LANG environment variable");
         }
     }
 
@@ -54,6 +61,7 @@ class LocaleInitializer {
                 Locale l = new Locale.Builder().setLanguageTag(sb.toString()).build();
                 if (l != null) {
                     Locale.setDefault(l);
+                    logger.debug("Java Locale changed to {}", l);
                     return true;
                 }
             }

--- a/src/main/java/org/utplsql/cli/ReportersCommand.java
+++ b/src/main/java/org/utplsql/cli/ReportersCommand.java
@@ -28,6 +28,7 @@ public class ReportersCommand implements ICommand {
 
     @Override
     public int run() {
+        LoggerConfiguration.configure(LoggerConfiguration.ConfigLevel.NONE);
 
         try {
             DataSource ds = DataSourceProvider.getDataSource(connectionString, 1);

--- a/src/main/java/org/utplsql/cli/RunAction.java
+++ b/src/main/java/org/utplsql/cli/RunAction.java
@@ -48,6 +48,7 @@ public class RunAction {
 
     void init() {
         LoggerConfiguration.configure(config.getLogConfigLevel());
+        LocaleInitializer.initLocale();
     }
 
     public RunCommandConfig getConfig() {

--- a/src/main/java/org/utplsql/cli/RunPicocliCommand.java
+++ b/src/main/java/org/utplsql/cli/RunPicocliCommand.java
@@ -99,7 +99,7 @@ public class RunPicocliCommand implements IRunCommand {
     private List<Format> reporters = new ArrayList<>();
 
     static class Format {
-        @Option(names = {"-f", "--format"}, required = true, description = "Enables specified format reporting", defaultValue = "ut_documentation_reporter")
+        @Option(names = {"-f", "--format"}, required = true, description = "Enables specified format reporting")
         String format;
         @Option(names = {"-o"}, description = "Outputs format to file")
         String outputFile;

--- a/src/main/java/org/utplsql/cli/RunPicocliCommand.java
+++ b/src/main/java/org/utplsql/cli/RunPicocliCommand.java
@@ -99,7 +99,7 @@ public class RunPicocliCommand implements IRunCommand {
     private List<Format> reporters = new ArrayList<>();
 
     static class Format {
-        @Option(names = {"-f", "--format"}, required = true, description = "Enables specified format reporting")
+        @Option(names = {"-f", "--format"}, required = true, description = "Enables specified format reporting", defaultValue = "ut_documentation_reporter")
         String format;
         @Option(names = {"-o"}, description = "Outputs format to file")
         String outputFile;

--- a/src/main/java/org/utplsql/cli/VersionInfoCommand.java
+++ b/src/main/java/org/utplsql/cli/VersionInfoCommand.java
@@ -23,6 +23,7 @@ public class VersionInfoCommand implements ICommand {
     boolean help;
 
     public int run() {
+        LoggerConfiguration.configure(LoggerConfiguration.ConfigLevel.NONE);
 
         System.out.println(CliVersionInfo.getInfo());
         System.out.println(JavaApiVersionInfo.getInfo());

--- a/src/main/java/org/utplsql/cli/config/ReporterConfig.java
+++ b/src/main/java/org/utplsql/cli/config/ReporterConfig.java
@@ -1,5 +1,7 @@
 package org.utplsql.cli.config;
 
+import org.utplsql.api.reporter.CoreReporters;
+
 import java.beans.ConstructorProperties;
 
 public class ReporterConfig {
@@ -10,7 +12,11 @@ public class ReporterConfig {
 
     @ConstructorProperties({"name", "output", "forceToScreen"})
     public ReporterConfig(String name, String output, Boolean forceToScreen) {
-        this.name = name;
+        if ( name != null ) {
+            this.name = name;
+        } else {
+            this.name = CoreReporters.UT_DOCUMENTATION_REPORTER.name();
+        }
         this.output = output;
         if (forceToScreen != null) this.forceToScreen = forceToScreen;
     }

--- a/src/test/java/org/utplsql/cli/PicocliRunCommandTest.java
+++ b/src/test/java/org/utplsql/cli/PicocliRunCommandTest.java
@@ -164,6 +164,20 @@ public class PicocliRunCommandTest {
     }
 
     @Test
+    void outputWithDefaultReporter() throws Exception {
+        RunCommandConfig config = parseForConfig("run",
+                TestHelper.getConnectionString(),
+                "-o=output1.txt");
+
+        assertNotNull( config.getReporters() );
+
+        ReporterConfig reporterConfig = config.getReporters()[0];
+        assertEquals("ut_documentation_reporter", reporterConfig.getName());
+        assertEquals("output1.txt", reporterConfig.getOutput());
+        assertFalse(reporterConfig.isForceToScreen());
+    }
+
+    @Test
     void sourceFileMapping() throws Exception {
         RunCommandConfig config = parseForConfig("run",
                 TestHelper.getConnectionString(),

--- a/src/test/java/org/utplsql/cli/PicocliRunCommandTest.java
+++ b/src/test/java/org/utplsql/cli/PicocliRunCommandTest.java
@@ -172,7 +172,7 @@ public class PicocliRunCommandTest {
         assertNotNull( config.getReporters() );
 
         ReporterConfig reporterConfig = config.getReporters()[0];
-        assertEquals("ut_documentation_reporter", reporterConfig.getName());
+        assertEquals("ut_documentation_reporter", reporterConfig.getName().toLowerCase());
         assertEquals("output1.txt", reporterConfig.getOutput());
         assertFalse(reporterConfig.isForceToScreen());
     }

--- a/src/test/java/org/utplsql/cli/RunCommandIT.java
+++ b/src/test/java/org/utplsql/cli/RunCommandIT.java
@@ -75,4 +75,18 @@ class RunCommandIT extends AbstractFileOutputTest {
 
         assertValidReturnCode(result);
     }
+
+    @Test
+    void run_withOutputButNoReporterDefined() throws Exception {
+
+        String outputFileName = "output_" + System.currentTimeMillis() + ".xml";
+        addTempPath(Paths.get(outputFileName));
+
+        int result = TestHelper.runApp("run",
+                TestHelper.getConnectionString(),
+                "-o=" + outputFileName,
+                "--failure-exit-code=2");
+
+        assertValidReturnCode(result);
+    }
 }


### PR DESCRIPTION
- Logs information about Default-Locale being changed by `LC_ALL`
- Moves Locale Initialization from Main to Run-Action
- Make `ut_documentation_reporter` the default value of the commandline (fixes #170)
- Add description about charset-handling to README (fixes #169)