### PR TITLE
Support `a_coverage_schemes` option of utPLSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ utplsql run "my/Username"/"myP@ssword"@connectstring
 
 -seed              - Sets the seed to use for random test execution order. If set, it sets -random to true
 (--random-test-order-seed)
+
+--coverage-schemes - A comma separated list of schemas on which coverage should be gathered
+                     Format: --coverage-schemes=schema1[,schema2[,schema3]]
 ```
 
 Parameters -f, -o, -s are correlated. That is parameters -o and -s are controlling outputs for reporter specified by the preceding -f parameter.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.utplsql</groupId>
   <artifactId>cli</artifactId>
-  <version>3.1.8-SNAPSHOT</version>
+  <version>3.1.9-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cli</name>
@@ -23,7 +23,7 @@
       <dependency>
           <groupId>org.utplsql</groupId>
           <artifactId>java-api</artifactId>
-          <version>3.1.8</version>
+          <version>3.1.9-SNAPSHOT</version>
           <scope>compile</scope>
           <exclusions>
               <exclusion>

--- a/src/main/java/org/utplsql/cli/RunAction.java
+++ b/src/main/java/org/utplsql/cli/RunAction.java
@@ -165,7 +165,8 @@ public class RunAction {
                 .excludeObjects(Arrays.asList(config.getExcludePackages()))
                 .randomTestOrder(config.isRandomTestOrder())
                 .randomTestOrderSeed(config.getRandomTestOrderSeed())
-                .addTags(Arrays.asList(config.getTags()));
+                .addTags(Arrays.asList(config.getTags()))
+                .addCoverageSchemes(Arrays.asList(config.getCoverageSchemes()));
     }
 
     private void outputMainInformation() {

--- a/src/main/java/org/utplsql/cli/RunPicocliCommand.java
+++ b/src/main/java/org/utplsql/cli/RunPicocliCommand.java
@@ -28,6 +28,11 @@ public class RunPicocliCommand implements IRunCommand {
             split = ",")
     private List<String> tags = new ArrayList<>();
 
+    @Option(names = {"--coverage-schemes"},
+            description = "comma-separated list of schemas on which coverage should be gathered",
+            split = ",")
+    private List<String> coverageSchemes = new ArrayList<>();
+
 
     @Option(
             names = {"-c", "--color"},
@@ -238,7 +243,8 @@ public class RunPicocliCommand implements IRunCommand {
                 enableDbmsOutput,
                 randomTestOrder,
                 randomTestOrderSeed,
-                tags.toArray(new String[0]));
+                tags.toArray(new String[0]),
+                coverageSchemes.toArray(new String[0]));
     }
 
     private RunAction getRunAction() {

--- a/src/main/java/org/utplsql/cli/RunPicocliCommand.java
+++ b/src/main/java/org/utplsql/cli/RunPicocliCommand.java
@@ -227,24 +227,25 @@ public class RunPicocliCommand implements IRunCommand {
             }
         }
 
-        return new RunCommandConfig(
-                connectionString,
-                suitePaths.toArray(new String[0]),
-                reporterConfigs.toArray(new ReporterConfig[0]),
-                colorConsole,
-                failureExitCode,
-                skipCompatibilityCheck,
-                splitOrEmpty(includeObjects),
-                splitOrEmpty(excludeObjects),
-                sourceFileMapping,
-                testFileMapping,
-                loggerConfigLevel,
-                timeoutInMinutes,
-                enableDbmsOutput,
-                randomTestOrder,
-                randomTestOrderSeed,
-                tags.toArray(new String[0]),
-                coverageSchemes.toArray(new String[0]));
+        return new RunCommandConfig.Builder()
+                .connectString(connectionString)
+                .suitePaths(suitePaths.toArray(new String[0]))
+                .reporters(reporterConfigs.toArray(new ReporterConfig[0]))
+                .outputAnsiColor(colorConsole)
+                .failureExitCode(failureExitCode)
+                .skipCompatibilityCheck(skipCompatibilityCheck)
+                .includePackages(splitOrEmpty(includeObjects))
+                .excludePackages(splitOrEmpty(excludeObjects))
+                .sourceMapping(sourceFileMapping)
+                .testMapping(testFileMapping)
+                .logConfigLevel(loggerConfigLevel)
+                .timeoutInMinutes(timeoutInMinutes)
+                .dbmsOutput(enableDbmsOutput)
+                .randomTestOrder(randomTestOrder)
+                .randomTestOrderSeed(randomTestOrderSeed)
+                .tags(tags.toArray(new String[0]))
+                .coverageSchemes(coverageSchemes.toArray(new String[0]))
+                .create();
     }
 
     private RunAction getRunAction() {

--- a/src/main/java/org/utplsql/cli/config/RunCommandConfig.java
+++ b/src/main/java/org/utplsql/cli/config/RunCommandConfig.java
@@ -105,5 +105,117 @@ public class RunCommandConfig extends ConnectionConfig {
         return randomTestOrderSeed;
     }
 
-    public String[] getCoverageSchemes() { return coverageSchemes; }
+    public String[] getCoverageSchemes() {
+        return coverageSchemes;
+    }
+
+    public static class Builder {
+
+        private String connectString;
+        private String[] suitePaths;
+        private ReporterConfig[] reporters;
+        private boolean outputAnsiColor;
+        private Integer failureExitCode;
+        private boolean skipCompatibilityCheck;
+        private String[] includePackages;
+        private String[] excludePackages;
+        private FileMapperConfig sourceMapping;
+        private FileMapperConfig testMapping;
+        private ConfigLevel logConfigLevel;
+        private Integer timeoutInMinutes;
+        private boolean dbmsOutput;
+        private boolean randomTestOrder;
+        private Integer randomTestOrderSeed;
+        private String[] tags;
+        private String[] coverageSchemes;
+
+        public Builder connectString(String connectString) {
+            this.connectString = connectString;
+            return this;
+        }
+
+        public Builder suitePaths(String[] suitePaths) {
+            this.suitePaths = suitePaths;
+            return this;
+        }
+
+        public Builder reporters(ReporterConfig[] reporters) {
+            this.reporters = reporters;
+            return this;
+        }
+
+        public Builder outputAnsiColor(boolean outputAnsiColor) {
+            this.outputAnsiColor = outputAnsiColor;
+            return this;
+        }
+
+        public Builder failureExitCode(Integer failureExitCode) {
+            this.failureExitCode = failureExitCode;
+            return this;
+        }
+
+        public Builder skipCompatibilityCheck(boolean skipCompatibilityCheck) {
+            this.skipCompatibilityCheck = skipCompatibilityCheck;
+            return this;
+        }
+
+        public Builder includePackages(String[] includePackages) {
+            this.includePackages = includePackages;
+            return this;
+        }
+
+        public Builder excludePackages(String[] excludePackages) {
+            this.excludePackages = excludePackages;
+            return this;
+        }
+
+        public Builder sourceMapping(FileMapperConfig sourceMapping) {
+            this.sourceMapping = sourceMapping;
+            return this;
+        }
+
+        public Builder testMapping(FileMapperConfig testMapping) {
+            this.testMapping = testMapping;
+            return this;
+        }
+
+        public Builder logConfigLevel(ConfigLevel logConfigLevel) {
+            this.logConfigLevel = logConfigLevel;
+            return this;
+        }
+
+        public Builder timeoutInMinutes(Integer timeoutInMinutes) {
+            this.timeoutInMinutes = timeoutInMinutes;
+            return this;
+        }
+
+        public Builder dbmsOutput(boolean dbmsOutput) {
+            this.dbmsOutput = dbmsOutput;
+            return this;
+        }
+
+        public Builder randomTestOrder(boolean randomTestOrder) {
+            this.randomTestOrder = randomTestOrder;
+            return this;
+        }
+
+        public Builder randomTestOrderSeed(Integer randomTestOrderSeed) {
+            this.randomTestOrderSeed = randomTestOrderSeed;
+            return this;
+        }
+
+        public Builder tags(String[] tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder coverageSchemes(String[] coverageSchemes) {
+            this.coverageSchemes = coverageSchemes;
+            return this;
+        }
+
+        public RunCommandConfig create() {
+            return new RunCommandConfig(connectString, suitePaths, reporters, outputAnsiColor, failureExitCode, skipCompatibilityCheck, includePackages, excludePackages, sourceMapping, testMapping, logConfigLevel, timeoutInMinutes, dbmsOutput, randomTestOrder, randomTestOrderSeed, tags, coverageSchemes);
+        }
+    }
 }

--- a/src/main/java/org/utplsql/cli/config/RunCommandConfig.java
+++ b/src/main/java/org/utplsql/cli/config/RunCommandConfig.java
@@ -22,9 +22,10 @@ public class RunCommandConfig extends ConnectionConfig {
     private boolean randomTestOrder = false;
     private final Integer randomTestOrderSeed;
     private final String[] tags;
+    private final String[] coverageSchemes;
 
-    @ConstructorProperties({"connectString", "suitePaths", "reporters", "outputAnsiColor", "failureExitCode", "skipCompatibilityCheck", "includePackages", "excludePackages", "sourceMapping", "testMapping", "logConfigLevel", "timeoutInMinutes", "dbmsOutput", "randomTestOrder", "randomTestOrderSeed", "tags"})
-    public RunCommandConfig(String connectString, String[] suitePaths, ReporterConfig[] reporters, boolean outputAnsiColor, Integer failureExitCode, boolean skipCompatibilityCheck, String[] includePackages, String[] excludePackages, FileMapperConfig sourceMapping, FileMapperConfig testMapping, ConfigLevel logConfigLevel, Integer timeoutInMinutes, boolean dbmsOutput, boolean randomTestOrder, Integer randomTestOrderSeed, String[] tags) {
+    @ConstructorProperties({"connectString", "suitePaths", "reporters", "outputAnsiColor", "failureExitCode", "skipCompatibilityCheck", "includePackages", "excludePackages", "sourceMapping", "testMapping", "logConfigLevel", "timeoutInMinutes", "dbmsOutput", "randomTestOrder", "randomTestOrderSeed", "tags", "coverageSchemes"})
+    public RunCommandConfig(String connectString, String[] suitePaths, ReporterConfig[] reporters, boolean outputAnsiColor, Integer failureExitCode, boolean skipCompatibilityCheck, String[] includePackages, String[] excludePackages, FileMapperConfig sourceMapping, FileMapperConfig testMapping, ConfigLevel logConfigLevel, Integer timeoutInMinutes, boolean dbmsOutput, boolean randomTestOrder, Integer randomTestOrderSeed, String[] tags, String[] coverageSchemes) {
         super(connectString);
         this.suitePaths = suitePaths;
         this.reporters = reporters;
@@ -41,6 +42,7 @@ public class RunCommandConfig extends ConnectionConfig {
         this.randomTestOrder = randomTestOrder;
         this.randomTestOrderSeed = randomTestOrderSeed;
         this.tags = tags;
+        this.coverageSchemes = coverageSchemes;
     }
 
     public String[] getSuitePaths() {
@@ -102,4 +104,6 @@ public class RunCommandConfig extends ConnectionConfig {
     public Integer getRandomTestOrderSeed() {
         return randomTestOrderSeed;
     }
+
+    public String[] getCoverageSchemes() { return coverageSchemes; }
 }

--- a/src/main/java/org/utplsql/cli/config/RunCommandConfig.java
+++ b/src/main/java/org/utplsql/cli/config/RunCommandConfig.java
@@ -112,13 +112,13 @@ public class RunCommandConfig extends ConnectionConfig {
     public static class Builder {
 
         private String connectString;
-        private String[] suitePaths;
+        private String[] suitePaths = new String[0];
         private ReporterConfig[] reporters;
         private boolean outputAnsiColor;
         private Integer failureExitCode;
         private boolean skipCompatibilityCheck;
-        private String[] includePackages;
-        private String[] excludePackages;
+        private String[] includePackages = new String[0];
+        private String[] excludePackages = new String[0];
         private FileMapperConfig sourceMapping;
         private FileMapperConfig testMapping;
         private ConfigLevel logConfigLevel;
@@ -126,8 +126,8 @@ public class RunCommandConfig extends ConnectionConfig {
         private boolean dbmsOutput;
         private boolean randomTestOrder;
         private Integer randomTestOrderSeed;
-        private String[] tags;
-        private String[] coverageSchemes;
+        private String[] tags = new String[0];
+        private String[] coverageSchemes = new String[0];
 
         public Builder connectString(String connectString) {
             this.connectString = connectString;

--- a/src/test/java/org/utplsql/cli/PicocliRunCommandTest.java
+++ b/src/test/java/org/utplsql/cli/PicocliRunCommandTest.java
@@ -48,7 +48,8 @@ public class PicocliRunCommandTest {
                     "-type_mapping=\"tsql=PACKAGE BODY\"",
                     "-owner_subexpression=1",
                     "-type_subexpression=2",
-                    "-name_subexpression=3");
+                    "-name_subexpression=3",
+                "--coverage-schemes=schema1,other_schema");
 
         assertNotNull(config.getConnectString());
         assertThat( config.getSuitePaths(), is(new String[]{"app.betwnstr", "app.basic"}));
@@ -65,6 +66,7 @@ public class PicocliRunCommandTest {
         assertEquals( 123, config.getRandomTestOrderSeed() );
         assertNotNull( config.getReporters() );
         assertEquals( 1, config.getReporters().length );
+        assertThat( config.getCoverageSchemes(), is(new String[]{"schema1", "other_schema"}) );
 
         // Source FileMapping
         assertNotNull(config.getSourceMapping());

--- a/src/test/java/org/utplsql/cli/RunCommandArgumentsTest.java
+++ b/src/test/java/org/utplsql/cli/RunCommandArgumentsTest.java
@@ -18,6 +18,7 @@ public class RunCommandArgumentsTest {
                     "-o=sonar_result.xml",
                     "-s",
                 "--tags=tag1,tag2",
+                "--coverage-schemes=schema1,some_other_schema",
                 "-d",
                 "-c",
                 "--failure-exit-code=10",
@@ -63,5 +64,15 @@ public class RunCommandArgumentsTest {
 
         TestRunner testRunner = runCmd.newTestRunner(new ArrayList<>());
         assertThat( testRunner.getOptions().tags, contains("tag1", "tag.2") );
+    }
+
+    @Test
+    void provideCoverageSchemes() {
+        IRunCommand runCmd = TestHelper.createRunCommand(TestHelper.getConnectionString(),
+                "--coverage-schemes=schema-1,some_other_schema"
+        );
+
+        TestRunner testRunner = runCmd.newTestRunner(new ArrayList<>());
+        assertThat( testRunner.getOptions().coverageSchemes, contains("schema-1", "some_other_schema") );
     }
 }

--- a/src/test/java/org/utplsql/cli/RunCommandConfigParamsArePassedToTestRunnerTest.java
+++ b/src/test/java/org/utplsql/cli/RunCommandConfigParamsArePassedToTestRunnerTest.java
@@ -1,0 +1,31 @@
+package org.utplsql.cli;
+
+import org.junit.jupiter.api.Test;
+import org.utplsql.api.TestRunner;
+import org.utplsql.cli.config.RunCommandConfig;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+public class RunCommandConfigParamsArePassedToTestRunnerTest {
+
+    @Test
+    void tags() {
+        RunCommandConfig config = new RunCommandConfig.Builder()
+                .tags(new String[]{"tag1", "tag2"})
+                .create();
+        TestRunner testRunner = new RunAction(config).newTestRunner(new ArrayList<>());
+        assertThat( testRunner.getOptions().tags, contains("tag1", "tag2") );
+    }
+
+    @Test
+    void coverageSchemes() {
+        RunCommandConfig config = new RunCommandConfig.Builder()
+                .coverageSchemes(new String[]{"schema1", "another_schema", "and-another-one"})
+                .create();
+        TestRunner testRunner = new RunAction(config).newTestRunner(new ArrayList<>());
+        assertThat( testRunner.getOptions().coverageSchemes, contains("schema1", "another_schema", "and-another-one") );
+    }
+}


### PR DESCRIPTION
Add a new command-line parameter `--coverage-schemes` which populates utPLSQL's `a_coverage_schemes` parameter.

The parameter lets you specify different schemas for which coverage information is gathered.
See http://utplsql.org/utPLSQL/develop/userguide/coverage.html#setting-coverage-schemas

Fixes #174 