### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,17 +43,17 @@
       <dependency>
           <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
-          <version>2.3.0</version>
+          <version>2.3.1</version>
       </dependency>
       <dependency>
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
-          <version>1.2.3</version>
+          <version>1.2.11</version>
       </dependency>
       <dependency>
           <groupId>info.picocli</groupId>
           <artifactId>picocli</artifactId>
-          <version>4.0.0-beta-1b</version>
+          <version>4.6.3</version>
       </dependency>
       <dependency>
           <groupId>com.oracle.ojdbc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,19 +56,19 @@
           <version>4.6.3</version>
       </dependency>
       <dependency>
-          <groupId>com.oracle.ojdbc</groupId>
+          <groupId>com.oracle.database.jdbc</groupId>
           <artifactId>ojdbc8</artifactId>
           <version>${oracle.jdbc.version}</version>
           <scope>compile</scope>
           <exclusions>
               <exclusion>
-                  <groupId>com.oracle.ojdbc</groupId>
+                  <groupId>com.oracle.database.jdbc</groupId>
                   <artifactId>ucp</artifactId>
               </exclusion>
           </exclusions>
       </dependency>
      <dependency>
-          <groupId>com.oracle.ojdbc</groupId>
+          <groupId>com.oracle.database.nls</groupId>
           <artifactId>orai18n</artifactId>
           <version>${oracle.jdbc.version}</version>
           <scope>compile</scope>

--- a/src/main/java/org/utplsql/cli/Cli.java
+++ b/src/main/java/org/utplsql/cli/Cli.java
@@ -1,10 +1,14 @@
 package org.utplsql.cli;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import java.util.List;
 
 public class Cli {
+
+    private static final Logger logger = LoggerFactory.getLogger(Cli.class);
 
     static final int DEFAULT_ERROR_CODE = 1;
 
@@ -16,6 +20,8 @@ public class Cli {
     }
 
     static int runPicocliWithExitCode(String[] args) {
+
+        logger.debug("Args: "+String.join(", ", args));
 
         CommandLine commandLine = new CommandLine(UtplsqlPicocliCommand.class);
         commandLine.setTrimQuotes(true);

--- a/src/main/java/org/utplsql/cli/RunPicocliCommand.java
+++ b/src/main/java/org/utplsql/cli/RunPicocliCommand.java
@@ -104,7 +104,7 @@ public class RunPicocliCommand implements IRunCommand {
     private List<Format> reporters = new ArrayList<>();
 
     static class Format {
-        @Option(names = {"-f", "--format"}, required = true, description = "Enables specified format reporting")
+        @Option(names = {"-f", "--format"}, description = "Enables specified format reporting")
         String format;
         @Option(names = {"-o"}, description = "Outputs format to file")
         String outputFile;

--- a/src/main/java/org/utplsql/cli/datasource/TestedDataSourceProvider.java
+++ b/src/main/java/org/utplsql/cli/datasource/TestedDataSourceProvider.java
@@ -54,6 +54,7 @@ public class TestedDataSourceProvider {
         ds.setPassword(config.getPassword());
 
         for (ConnectStringPossibility possibility : possibilities) {
+            logger.debug("Try connecting {}", possibility.getMaskedConnectString(config));
             ds.setURL(possibility.getConnectString(config));
             try (Connection ignored = ds.getConnection()) {
                 logger.info("Use connection string {}", possibility.getMaskedConnectString(config));

--- a/src/main/java/org/utplsql/cli/datasource/TestedDataSourceProvider.java
+++ b/src/main/java/org/utplsql/cli/datasource/TestedDataSourceProvider.java
@@ -58,7 +58,7 @@ public class TestedDataSourceProvider {
             try (Connection ignored = ds.getConnection()) {
                 logger.info("Use connection string {}", possibility.getMaskedConnectString(config));
                 return;
-            } catch (UnsatisfiedLinkError | Exception e) {
+            } catch (Error | Exception e) {
                 errors.add(possibility.getMaskedConnectString(config) + ": " + e.getMessage());
                 lastException = e;
             }

--- a/src/test/java/org/utplsql/cli/PicocliRunCommandTest.java
+++ b/src/test/java/org/utplsql/cli/PicocliRunCommandTest.java
@@ -240,4 +240,13 @@ public class PicocliRunCommandTest {
         assertNull( testMapperConfig.getTypeSubexpression());
         assertNull( testMapperConfig.getNameSubexpression());
     }
+
+    @Test
+    void negatedTag() throws Exception {
+        RunCommandConfig config = parseForConfig("run",
+                TestHelper.getConnectionString(),
+                "--tags=\"-dontwantit\"");
+
+        assertThat(config.getTags(), hasItemInArray("-dontwantit") );
+    }
 }


### PR DESCRIPTION
Use logback 1.2.11 to omit known security issues.
Use more recent stable versions of jaxb-api and picocli

Fixes #203